### PR TITLE
chore: upgrade supported node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
node のサポートバージョンから 10 系を削除、16 系を追加しました。