### PR TITLE
lint 関連ツールを一括でインストールするための CLI パッケージを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "build": "yarn tsc",
+    "build": "lerna run prebuild --stream && yarn tsc",
     "prebuild": "lerna run clean --stream",
     "lint": "eslint '**/*.{ts,tsx}'",
     "release": "lerna publish --conventional-commits",

--- a/packages/create-lint-set/LICENSE
+++ b/packages/create-lint-set/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright 2022 SmartHR
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/create-lint-set/README.md
+++ b/packages/create-lint-set/README.md
@@ -1,0 +1,22 @@
+# `@smarthr/create-lint-set`
+
+各種リントツールを一括でインストールするための CLI です。
+
+## Usage
+
+```bash
+$ npx @smarthr/create-lint-set
+```
+
+## Options
+
+第1引数に対象となるディレクトリ名を指定できます。
+デフォルト値は `.` です。
+
+```bash
+$ npx @smarthr/create-lint-set your/project/directory
+```
+
+## License
+
+This project is licensed under the terms of the [MIT license](https://github.com/kufu/tamatebako/blob/master/packages/create-lint-set/LICENSE).

--- a/packages/create-lint-set/package.json
+++ b/packages/create-lint-set/package.json
@@ -22,8 +22,9 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "yarn copy-templates",
     "copy-templates": "mkdir lib && cp -r src/templates lib/templates",
-    "clean": "rimraf lib && yarn copy-templates"
+    "clean": "rimraf lib"
   },
   "dependencies": {
     "chalk": "4.1.2",

--- a/packages/create-lint-set/package.json
+++ b/packages/create-lint-set/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@smarthr/create-lint-set",
+  "version": "1.0.0",
+  "description": "",
+  "author": "SmartHR",
+  "homepage": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kufu/tamatebako.git",
+    "directory": "packages/create-lint-set"
+  },
+  "bugs": {
+    "url": "https://github.com/kufu/tamatebako/issues"
+  },
+  "license": "MIT",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "copy-templates": "mkdir lib && cp -r src/templates lib/templates",
+    "clean": "rimraf lib && yarn copy-templates"
+  },
+  "dependencies": {
+    "chalk": "4.1.2",
+    "commander": "^9.1.0",
+    "cross-spawn": "^7.0.3",
+    "fs-extra": "^10.0.1"
+  },
+  "devDependencies": {
+    "@types/cross-spawn": "^6.0.2"
+  }
+}

--- a/packages/create-lint-set/package.json
+++ b/packages/create-lint-set/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@smarthr/create-lint-set",
   "version": "1.0.0",
-  "description": "",
+  "description": "Lint installer",
   "author": "SmartHR",
-  "homepage": "",
+  "homepage": "https://github.com/kufu/tamatebako/tree/master/packages/create-lint-set",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kufu/tamatebako.git",

--- a/packages/create-lint-set/src/createLintSet.ts
+++ b/packages/create-lint-set/src/createLintSet.ts
@@ -1,0 +1,136 @@
+import { program } from 'commander'
+import chalk from 'chalk'
+import spawn from 'cross-spawn'
+const path = require('path')
+const fs = require('fs-extra')
+
+import { Item, items } from './items'
+
+// CLI 実行時のオプションを取得
+const getOptions = () => {
+  const packageJson = require('../package.json')
+  let projectPath = '.'
+  program
+    .name(packageJson.name)
+    .version(packageJson.version)
+    .argument('[project-path]', 'path to your project', '.')
+    .usage(`${chalk.green('[project-path]')}`)
+    .action((name) => {
+      projectPath = name
+    })
+    .parse(process.argv)
+
+  return { projectPath }
+}
+
+// すでにインストールされているパッケージを除く
+const filterInstallPackages = (targetDir: string, itemList: Item[]) => {
+  const packageJsonPath = path.resolve(targetDir, 'package.json')
+  if (!fs.existsSync(packageJsonPath)) {
+    console.error(chalk.red('package.json was not found.'))
+    process.exit(1)
+  }
+  const packageJson = require(packageJsonPath)
+  const installedPackages = [
+    ...Object.keys(packageJson.dependencies ?? {}),
+    ...Object.keys(packageJson.devDependencies ?? {}),
+  ]
+
+  return itemList.map((item) => ({
+    ...item,
+    packages: item.packages.filter((itemPackage) => !installedPackages.includes(itemPackage)),
+  }))
+}
+
+// インストール
+const installPackages = async (
+  targetDir: string,
+  itemList: Item[],
+  useYarn: boolean,
+): Promise<void> => {
+  const targetPackages = itemList.map((item) => item.packages).flat()
+  let command: string
+  let args: string[]
+  if (useYarn) {
+    command = 'yarn'
+    args = ['add', '--dev', '--exact', '--cwd', targetDir, ...targetPackages]
+  } else {
+    command = 'npm'
+    args = ['install', '--save-dev', '--save-exact', '--prefix', targetDir, ...targetPackages]
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, { stdio: 'inherit' })
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject()
+      }
+      resolve()
+    })
+  })
+}
+
+// すでに設定ファイルが存在するかどうかの確認
+const shouldCreateConfigFile = (regex: RegExp, fileNames: string[]) => {
+  let shouldCreate = true
+  for (const fileName of fileNames) {
+    if (shouldCreate && regex.test(fileName)) shouldCreate = false
+  }
+  return shouldCreate
+}
+
+// 設定ファイルの作成
+const createConfigFiles = (
+  scriptDir: string,
+  targetDir: string,
+  targetDirFiles: string[],
+  itemList: Item[],
+) => {
+  itemList.forEach((item) => {
+    if (shouldCreateConfigFile(item.configFilePattern, targetDirFiles)) {
+      const templateDir = scriptDir + '/templates/' + item.templateDirName
+      fs.copySync(templateDir, targetDir)
+    }
+  })
+}
+
+const printMessage = (itemList: Item[]) => {
+  const installedPackageCount = itemList.map((item) => item.packages).flat().length
+  if (installedPackageCount > 0) {
+    let isFirst = true
+    let packageListString = ''
+
+    itemList.forEach((installedItem) => {
+      if (installedItem.packages.length && installedItem.npmScriptsSample) {
+        packageListString += `${isFirst ? '' : ','}\n  ${installedItem.npmScriptsSample}`
+        isFirst = false
+      }
+    })
+    console.info(
+      chalk.green(
+        'Packages were successfully installed!🍺\nAdd something like below to your package.json.\n',
+      ),
+    )
+    // 下記のような文字列の出力
+    // "scripts": {
+    //   "eslint": "eslint './**/*.ts{,x}'"
+    // }
+    console.info(chalk.cyan(`"scripts": {${packageListString}\n}\n`))
+  } else {
+    console.info(chalk.green('No packages were added.'))
+  }
+}
+
+export const init = async () => {
+  const { projectPath } = getOptions()
+  const scriptDir: string = __dirname // このスクリプト自体があるディレクトリ
+  const currentDir: string = path.resolve() // npx が実行されているディレクトリ
+  const targetDir: string = path.join(currentDir, projectPath) // 対象プロジェクトのディレクトリ
+  const targetDirFiles: string[] = fs.readdirSync(targetDir) // 対象プロジェクトの直下のファイル名配列
+  const isUsingYarn: boolean = targetDirFiles.includes('yarn.lock')
+
+  const itemsWithFilteredPackages = filterInstallPackages(targetDir, items)
+  await installPackages(targetDir, itemsWithFilteredPackages, isUsingYarn)
+  createConfigFiles(scriptDir, targetDir, targetDirFiles, items)
+  printMessage(itemsWithFilteredPackages)
+}

--- a/packages/create-lint-set/src/index.ts
+++ b/packages/create-lint-set/src/index.ts
@@ -1,0 +1,14 @@
+import chalk from 'chalk/index'
+
+import { init } from './createLintSet'
+
+const currentNodeVersion = process.versions.node
+const versions = currentNodeVersion.split('.')
+const majorVersion = Number(versions[0])
+
+if (majorVersion < 14) {
+  console.error(chalk.red('Requires Node 14 or higher.'))
+  process.exit(1)
+}
+
+init()

--- a/packages/create-lint-set/src/index.ts
+++ b/packages/create-lint-set/src/index.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk/index'
+import chalk from 'chalk'
 
 import { init } from './createLintSet'
 

--- a/packages/create-lint-set/src/items.ts
+++ b/packages/create-lint-set/src/items.ts
@@ -1,0 +1,45 @@
+export type Item = {
+  name: string // 識別名
+  templateDirName: string // ライブラリ側で持っているテンプレートファイルのディレクトリ。この中のファイルをコピーする形で書き込む
+  packages: string[] // インストールする npm パッケージ名
+  configFilePattern: RegExp // 対象ディレクトリにすでに config があるかどうかを確認するための正規表現
+  npmScriptsSample?: string
+}
+
+export const items: Item[] = [
+  {
+    name: 'eslint',
+    templateDirName: 'eslint',
+    packages: ['eslint', 'eslint-config-smarthr', 'eslint-plugin-smarthr', 'prettier'],
+    configFilePattern: /\.eslintrc.*?/,
+    npmScriptsSample: '"eslint": "eslint \'./**/*.ts{,x}\'"',
+  },
+  {
+    name: 'prettier',
+    templateDirName: 'prettier',
+    packages: ['prettier', 'prettier-config-smarthr'],
+    configFilePattern: /\.prettierrc.*?/,
+  },
+  {
+    name: 'stylelint',
+    templateDirName: 'stylelint',
+    packages: [
+      'stylelint',
+      'stylelint-config-prettier',
+      'stylelint-config-smarthr',
+      'stylelint-config-standard',
+      'stylelint-config-styled-components',
+      'postcss-jsx',
+      'postcss-syntax',
+    ],
+    configFilePattern: /\.stylelintrc.*?/,
+    npmScriptsSample: '"stylelint": "stylelint \'./**/*.ts{,x}\'',
+  },
+  {
+    name: 'textlint',
+    templateDirName: 'textlint',
+    packages: ['textlint', 'textlint-plugin-jsx', 'textlint-rule-preset-smarthr'],
+    configFilePattern: /\.textlintrc.*?/,
+    npmScriptsSample: '"textlint": "textlint \'./**/*.ts{,x}\'',
+  },
+]

--- a/packages/create-lint-set/src/templates/eslint/.eslintrc
+++ b/packages/create-lint-set/src/templates/eslint/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "smarthr"
+}

--- a/packages/create-lint-set/src/templates/prettier/.prettierrc.js
+++ b/packages/create-lint-set/src/templates/prettier/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('prettier-config-smarthr'),
+}

--- a/packages/create-lint-set/src/templates/stylelint/.stylelintrc
+++ b/packages/create-lint-set/src/templates/stylelint/.stylelintrc
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "stylelint-config-smarthr"
+  ]
+}

--- a/packages/create-lint-set/src/templates/textlint/.textlintrc.yml
+++ b/packages/create-lint-set/src/templates/textlint/.textlintrc.yml
@@ -1,0 +1,8 @@
+rules:
+  preset-smarthr: true
+plugins:
+  jsx:
+    extensions:
+      - ".jsx"
+      - ".tsx"
+      - ".ts"

--- a/packages/create-lint-set/src/templates/textlint/.textlintrc.yml
+++ b/packages/create-lint-set/src/templates/textlint/.textlintrc.yml
@@ -2,7 +2,5 @@ rules:
   preset-smarthr: true
 plugins:
   jsx:
-    extensions:
-      - ".jsx"
-      - ".tsx"
+    extensions: # .jsx and .tsx are supported by default
       - ".ts"

--- a/packages/create-lint-set/tsconfig.json
+++ b/packages/create-lint-set/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "outDir": "./lib",
+    "rootDir": "./src"
+  }
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -4,6 +4,7 @@
   "references": [
     { "path": "./use-bulk-check" },
     { "path": "./use-virtual-scroll" },
-    { "path": "./wareki" }
+    { "path": "./wareki" },
+    { "path": "./create-lint-set" },
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3706,6 +3706,13 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/cross-spawn@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.2.tgz#168309de311cd30a2b8ae720de6475c2fbf33ac7"
+  integrity sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -5365,6 +5372,14 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
+chalk@4.1.2, chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -5386,14 +5401,6 @@ chalk@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -5688,6 +5695,11 @@ commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
+commander@^9.1.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
+  integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
 
 common-path-prefix@^3.0.0:
   version "3.0.0"
@@ -7495,6 +7507,15 @@ fs-extra@^0.30.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^10.0.1:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"


### PR DESCRIPTION
## やったこと

create-lint-set という名前で、SmartHR プロダクトで使っている lint ツールの一括インストール CLI を追加しました。
READEME.md に記載のとおりですが、`$ npx @smarthr/create-lint-set` を実行することで

- eslint
- prettier
- stylelint
- textlint

関連のパッケージが、最低限の設定ファイルとともにローカルにインストールされるイメージです。

## 確認方法

まず、実行対象となる適当なディレクトリを作成します。

`$ mkdir hoge`
`$ cd hoge`
`$ npm init -y`

その後、ローカル開発環境では下記のいずれかを実行します。
- tamatebako で `$ yarn build` 実行後に `$ node ~/your/path/tamatebako/create-lint-set/lib/index.js`
- `$ npx ts-node ~/your/path/tamatebako/create-lint-set/src/index.ts` (**ts-node を使う場合は ts ファイルを直接実行するので yarn build は不要**)

`hoge` ディレクトリ内にパッケージがインストールされ、各種設定ファイルが作成されていることを確認します。