### PR TITLE
feat: warekiの各メソッドのfallbackを書きやすくするため半角変換された日付テキストを常に返す

### DIFF
--- a/packages/wareki/src/__tests__/index.test.ts
+++ b/packages/wareki/src/__tests__/index.test.ts
@@ -1,5 +1,8 @@
 import { dateToWareki, warekiToDate } from '../index'
 
+const fullWidthToHalfWidth = (dateString: string) =>
+  dateString.replace(/[ａ-ｚＡ-Ｚ０-９．]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0))
+
 describe('wareki', () => {
   describe('dateToWareki', () => {
     it('Date を和暦に変換できること', () => {
@@ -20,10 +23,12 @@ describe('wareki', () => {
         ['明治0年1月25日', new Date(1867, 1 - 1, 25)],
         ['明治0年1月24日', new Date(1867, 1 - 1, 24)],
       ].forEach(([exptected, date]) => {
-        const actual = dateToWareki(date)
+        const d = date as Date
+        const actual = dateToWareki(d)
 
         expect(actual.isValid).toBeTruthy()
         expect(actual.result).toBe(exptected)
+        expect(actual.formatted).toBe(`${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`)
       })
     })
 
@@ -32,6 +37,7 @@ describe('wareki', () => {
         ['令和4年1月1日', '2022/1/1'],
         ['令和4年1月1日', '2022/01/01'],
         ['令和4年1月1日', '20220101'],
+        ['令和4年1月1日', '２０２２/１/１'],
         ['令和元年5月1日', '2019/5/1'],
         ['平成31年4月30日', '2019/4/30'],
         ['平成元年1月8日', '19890108'],
@@ -51,6 +57,7 @@ describe('wareki', () => {
 
         expect(actual.isValid).toBeTruthy()
         expect(actual.result).toBe(exptected)
+        expect(actual.formatted).toBe(fullWidthToHalfWidth(date))
       })
     })
   })
@@ -61,10 +68,22 @@ describe('wareki', () => {
         isValid: true,
         result: new Date(1869, 0, 1),
       }
-      expect(warekiToDate('明治2年1月1日')).toEqual(expected)
-      expect(warekiToDate('m2-1-1')).toEqual(expected)
-      expect(warekiToDate('M2-1-1')).toEqual(expected)
-      expect(warekiToDate('Ｍ2-1-1')).toEqual(expected)
+      expect(warekiToDate('明治2年1月1日')).toEqual({
+        ...expected,
+        formatted: '明治2年1月1日',
+      })
+      expect(warekiToDate('m2-1-1')).toEqual({
+        ...expected,
+        formatted: 'm2-1-1',
+      })
+      expect(warekiToDate('M2-1-1')).toEqual({
+        ...expected,
+        formatted: 'M2-1-1',
+      })
+      expect(warekiToDate('Ｍ2-1-1')).toEqual({
+        ...expected,
+        formatted: 'M2-1-1',
+      })
     })
 
     it('parse a date string of Taisho', () => {
@@ -72,10 +91,22 @@ describe('wareki', () => {
         isValid: true,
         result: new Date(1913, 0, 1),
       }
-      expect(warekiToDate('大正2年1月1日')).toEqual(expected)
-      expect(warekiToDate('t2-1-1')).toEqual(expected)
-      expect(warekiToDate('T2-1-1')).toEqual(expected)
-      expect(warekiToDate('Ｔ2-1-1')).toEqual(expected)
+      expect(warekiToDate('大正2年1月1日')).toEqual({
+        ...expected,
+        formatted: '大正2年1月1日',
+      })
+      expect(warekiToDate('t2-1-1')).toEqual({
+        ...expected,
+        formatted: 't2-1-1',
+      })
+      expect(warekiToDate('T2-1-1')).toEqual({
+        ...expected,
+        formatted: 'T2-1-1',
+      })
+      expect(warekiToDate('Ｔ2-1-1')).toEqual({
+        ...expected,
+        formatted: 'T2-1-1',
+      })
     })
 
     it('parse a date string of Showa', () => {
@@ -83,10 +114,22 @@ describe('wareki', () => {
         isValid: true,
         result: new Date(1927, 0, 1),
       }
-      expect(warekiToDate('昭和2年1月1日')).toEqual(expected)
-      expect(warekiToDate('s2-1-1')).toEqual(expected)
-      expect(warekiToDate('S2-1-1')).toEqual(expected)
-      expect(warekiToDate('Ｓ2-1-1')).toEqual(expected)
+      expect(warekiToDate('昭和2年1月1日')).toEqual({
+        ...expected,
+        formatted: '昭和2年1月1日',
+      })
+      expect(warekiToDate('s2-1-1')).toEqual({
+        ...expected,
+        formatted: 's2-1-1',
+      })
+      expect(warekiToDate('S2-1-1')).toEqual({
+        ...expected,
+        formatted: 'S2-1-1',
+      })
+      expect(warekiToDate('Ｓ2-1-1')).toEqual({
+        ...expected,
+        formatted: 'S2-1-1',
+      })
     })
 
     it('parse a date string of Heisei', () => {
@@ -94,10 +137,22 @@ describe('wareki', () => {
         isValid: true,
         result: new Date(1990, 0, 1),
       }
-      expect(warekiToDate('平成2年1月1日')).toEqual(expected)
-      expect(warekiToDate('h2-1-1')).toEqual(expected)
-      expect(warekiToDate('H2-1-1')).toEqual(expected)
-      expect(warekiToDate('Ｈ2-1-1')).toEqual(expected)
+      expect(warekiToDate('平成2年1月1日')).toEqual({
+        ...expected,
+        formatted: '平成2年1月1日',
+      })
+      expect(warekiToDate('h2-1-1')).toEqual({
+        ...expected,
+        formatted: 'h2-1-1',
+      })
+      expect(warekiToDate('H2-1-1')).toEqual({
+        ...expected,
+        formatted: 'H2-1-1',
+      })
+      expect(warekiToDate('Ｈ2-1-1')).toEqual({
+        ...expected,
+        formatted: 'H2-1-1',
+      })
     })
 
     it('parse a date string of Reiwa', () => {
@@ -105,10 +160,22 @@ describe('wareki', () => {
         isValid: true,
         result: new Date(2020, 0, 1),
       }
-      expect(warekiToDate('令和2年1月1日')).toEqual(expected)
-      expect(warekiToDate('r2-1-1')).toEqual(expected)
-      expect(warekiToDate('R2-1-1')).toEqual(expected)
-      expect(warekiToDate('Ｒ2-1-1')).toEqual(expected)
+      expect(warekiToDate('令和2年1月1日')).toEqual({
+        ...expected,
+        formatted: '令和2年1月1日',
+      })
+      expect(warekiToDate('r2-1-1')).toEqual({
+        ...expected,
+        formatted: 'r2-1-1',
+      })
+      expect(warekiToDate('R2-1-1')).toEqual({
+        ...expected,
+        formatted: 'R2-1-1',
+      })
+      expect(warekiToDate('Ｒ2-1-1')).toEqual({
+        ...expected,
+        formatted: 'R2-1-1',
+      })
     })
 
     it('parse a date string of japanese era that is an expected format', () => {
@@ -116,17 +183,42 @@ describe('wareki', () => {
         isValid: true,
         result: new Date(2020, 0, 1),
       }
-      expect(warekiToDate('r2:1:1')).toEqual(expected)
-      expect(warekiToDate('r2/1/1')).toEqual(expected)
-      expect(warekiToDate('r2-1-1')).toEqual(expected)
-      expect(warekiToDate('r2.1.1')).toEqual(expected)
-      expect(warekiToDate('r2 1 1')).toEqual(expected)
-      expect(warekiToDate('r2．1．1')).toEqual(expected)
-      expect(warekiToDate('r2年1月1日')).toEqual(expected)
-      expect(warekiToDate('r02:01:01')).toEqual(expected)
+      expect(warekiToDate('r2:1:1')).toEqual({
+        ...expected,
+        formatted: 'r2:1:1',
+      })
+      expect(warekiToDate('r2/1/1')).toEqual({
+        ...expected,
+        formatted: 'r2/1/1',
+      })
+      expect(warekiToDate('r2-1-1')).toEqual({
+        ...expected,
+        formatted: 'r2-1-1',
+      })
+      expect(warekiToDate('r2.1.1')).toEqual({
+        ...expected,
+        formatted: 'r2.1.1',
+      })
+      expect(warekiToDate('r2 1 1')).toEqual({
+        ...expected,
+        formatted: 'r2 1 1',
+      })
+      expect(warekiToDate('r2．1．1')).toEqual({
+        ...expected,
+        formatted: 'r2.1.1',
+      })
+      expect(warekiToDate('r2年1月1日')).toEqual({
+        ...expected,
+        formatted: 'r2年1月1日',
+      })
+      expect(warekiToDate('r02:01:01')).toEqual({
+        ...expected,
+        formatted: 'r02:01:01',
+      })
       expect(warekiToDate('r10:12:31')).toEqual({
         isValid: true,
         result: new Date(2028, 11, 31),
+        formatted: 'r10:12:31',
       })
     })
 
@@ -135,17 +227,42 @@ describe('wareki', () => {
         isValid: true,
         result: new Date(2020, 0, 1),
       }
-      expect(warekiToDate('2020:1:1')).toEqual(expected)
-      expect(warekiToDate('2020/1/1')).toEqual(expected)
-      expect(warekiToDate('2020-1-1')).toEqual(expected)
-      expect(warekiToDate('2020.1.1')).toEqual(expected)
-      expect(warekiToDate('2020 1 1')).toEqual(expected)
-      expect(warekiToDate('2020．1．1')).toEqual(expected)
-      expect(warekiToDate('2020年1月1日')).toEqual(expected)
-      expect(warekiToDate('20200101')).toEqual(expected)
+      expect(warekiToDate('2020:1:1')).toEqual({
+        ...expected,
+        formatted: '2020:1:1',
+      })
+      expect(warekiToDate('2020/1/1')).toEqual({
+        ...expected,
+        formatted: '2020/1/1',
+      })
+      expect(warekiToDate('2020-1-1')).toEqual({
+        ...expected,
+        formatted: '2020-1-1',
+      })
+      expect(warekiToDate('2020.1.1')).toEqual({
+        ...expected,
+        formatted: '2020.1.1',
+      })
+      expect(warekiToDate('2020 1 1')).toEqual({
+        ...expected,
+        formatted: '2020 1 1',
+      })
+      expect(warekiToDate('2020．1．1')).toEqual({
+        ...expected,
+        formatted: '2020.1.1',
+      })
+      expect(warekiToDate('2020年1月1日')).toEqual({
+        ...expected,
+        formatted: '2020年1月1日',
+      })
+      expect(warekiToDate('20200101')).toEqual({
+        ...expected,
+        formatted: '20200101',
+      })
       expect(warekiToDate('1999:12:31')).toEqual({
         isValid: true,
         result: new Date(1999, 11, 31),
+        formatted: '1999:12:31',
       })
     })
   })

--- a/packages/wareki/src/index.ts
+++ b/packages/wareki/src/index.ts
@@ -72,16 +72,19 @@ const fullWidthToHalfWidth = (dateString: string) =>
 type Result<T> = {
   isValid: boolean
   result: T
+  formatted: string
 }
 
 export function dateToWareki(d: string | Date): Result<string> {
   const dateString = d instanceof Date ? `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}` : d
-  const matcher = fullWidthToHalfWidth(dateString).match(reg.dateString)
+  const formatted = fullWidthToHalfWidth(dateString)
+  const matcher = formatted.match(reg.dateString)
 
   if (!matcher) {
     return {
       isValid: false,
       result: dateString,
+      formatted,
     }
   }
 
@@ -96,14 +99,15 @@ export function dateToWareki(d: string | Date): Result<string> {
   return {
     isValid: true,
     result: `${gengo}${warekiYear === 1 ? '元' : warekiYear}年${month}月${date}日`,
+    formatted,
   }
 }
 
 export function warekiToDate(wareki: string): Result<Date> {
-  const formattedWareki = fullWidthToHalfWidth(wareki)
+  const formatted = fullWidthToHalfWidth(wareki)
 
   // parse as japanese era
-  const matchedWareki = formattedWareki.match(reg.wareki)
+  const matchedWareki = formatted.match(reg.wareki)
 
   if (matchedWareki) {
     const baseYear = WAREKI_START_YEARS[matchedWareki[1] as keyof typeof WAREKI_START_YEARS]
@@ -116,21 +120,24 @@ export function warekiToDate(wareki: string): Result<Date> {
         Number(matchedWareki[4]) - 1,
         Number(matchedWareki[6]),
       ),
+      formatted,
     }
   }
 
   // parse as A.D.
-  const matchedDate = formattedWareki.match(reg.dateString)
+  const matchedDate = formatted.match(reg.dateString)
 
   if (matchedDate) {
     return {
       isValid: true,
       result: new Date(Number(matchedDate[1]), Number(matchedDate[3]) - 1, Number(matchedDate[5])),
+      formatted,
     }
   }
 
   return {
     isValid: false,
-    result: new Date(formattedWareki),
+    result: new Date(formatted),
+    formatted,
   }
 }


### PR DESCRIPTION
- warekiを使う際、resultがinvalid dateになることが間々ある
- その場合、全角->半角変換済みの値をday.jsなどに食わせるfallbackを行ったりする
- wareki内で上記変換は実施済みのため、resultに含めてreturnすることで使いやすくしたい