### PR TITLE
chore: 参照元の next-auth のライセンスを追記

### DIFF
--- a/packages/next-auth/src/RedisAdapter.ts
+++ b/packages/next-auth/src/RedisAdapter.ts
@@ -1,8 +1,26 @@
 /**
- * NextAuth の Upstash Redis Adapter のコードをそのまま持ってきて、
- * hydrateDates の最初に JSON.parse() を加えただけ
+ * modified from https://github.com/nextauthjs/next-auth/tree/main/packages/adapter-upstash-redis
+ *
+ * ISC License
+ *
+ * Copyright (c) 2022-2023, Balázs Orbán
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+/**
+ * NextAuth の Upstash Redis Adapter のコードの hydrateDates の最初に JSON.parse() を加えています
+ */
 import { v4 as uuid } from 'uuid'
 
 import type { Redis } from 'ioredis'


### PR DESCRIPTION
## やったこと

NextAuth の upstash redis adapter のコードをコピーして細部を変更しただけのコードに対して、コピー元の URL とライセンスを記載