### PR TITLE
feat: @smarthr/next-auth ログインに成功した時、アクセストークンの有効期限をアカウント情報に追加する

### DIFF
--- a/packages/next-auth/src/SmarthrProvider.ts
+++ b/packages/next-auth/src/SmarthrProvider.ts
@@ -35,6 +35,7 @@ export const SmarthrProvider = ({ smarthrUrl, redirectUri, clientId, clientSecre
         tokens: {
           access_token: data.access_token,
           refresh_token: data.refresh_token,
+          expires_in: data.expires_in,
         },
       }
     },


### PR DESCRIPTION
### やりたいこと

`@smarthr/next-auth` を使ってログインした際、アクセストークン・リフレッシュトークンに加えてアクセストークンの有効期限も取得したい

### やったこと

OAuth プロバイダがログインに成功した際に返す下記の情報を利用して、[Next-Auth が自動的に計算](https://github.com/nextauthjs/next-auth/blob/c7dec376a1272a0877c7e6fb2fc4173f08369f9f/packages/core/src/lib/oauth/callback.ts#L169-L172)した `expires_at` を返せるようにする。

OAuth プロバイダがログインに成功した際に返すデータ:

```js
{
  access_token: '[FILTERD]',
  refresh_token: '[FILTERD]',
  token_request_subdomain: null,
  scope: '[FILTERD]',
  token_request_tenant_id: null,
  token_type: 'Bearer',
  expires_in: 86400  // この値を `tokens` に追加する
}
```

`expires_in` を設定することで Next-Auth 側で `expires_at` が計算されて下記の account オブジェクトが返る:

```js
{
  provider: 'smarthr',
  type: 'oauth',
  providerAccountId: '[FILTERD]',
  access_token: '[FILTERD]',
  refresh_token: '[FILTERD]',
  expires_at: 1686733494
}
```