### PR TITLE
OAuthAccountNotLinkedエラー回避のため、emailが重複しないように設定するオプションを追加する

### DIFF
--- a/packages/next-auth/src/SmarthrProvider.ts
+++ b/packages/next-auth/src/SmarthrProvider.ts
@@ -6,9 +6,10 @@ type Arguments = {
   redirectUri: string
   clientId: string
   clientSecret: string
+  useUuidForEmail?: boolean
 }
 
-export const SmarthrProvider = ({ smarthrUrl, redirectUri, clientId, clientSecret }: Arguments): Provider => ({
+export const SmarthrProvider = ({ smarthrUrl, redirectUri, clientId, clientSecret, useUuidForEmail }: Arguments): Provider => ({
   id: 'smarthr',
   name: 'SmartHR',
   type: 'oauth',
@@ -51,7 +52,9 @@ export const SmarthrProvider = ({ smarthrUrl, redirectUri, clientId, clientSecre
   profile(profile) {
     return {
       id: profile.id,
-      email: profile.email ?? uuid(), // next-auth ではこの email を使って redis に値を入れるので、社員番号ログインで email がない場合は uuid を代わりとする
+      // email の重複による OAuthAccountNotLinked エラー避けるため、useUuidForEmail が true の場合は uuid を email として扱う
+      // 社員番号ログインで email がない場合も uuid を代わりとする
+      email: useUuidForEmail ? uuid() : profile.email ?? uuid(),
       uid: profile.id,
     }
   },


### PR DESCRIPTION
## 課題
- yosegiやkatanaなど、NextAuthを利用しているプロダクトで `OAuthAccountNotLinked` エラーが度々発生していました
- トライアルなどで一度プラスアプリにログインしたことがある状態で、そのログイン状態がRedisに残ったまま同メールアドレス・別アカウントでプラスアプリにアクセスした場合などにこのエラーになります
- このエラーが発生した場合、ユーザー側では対応できず、プロダクトチーム側でRedisのキーを手動で削除する対応が必要でした😭
- 詳しい経緯と内容は以下のDocBaseにまとめられています
  - [[yosegi] 20230817_認証エラー(OAuthAccountNotLinked)が発生してログインできない - DocBase](https://smarthr-inc.docbase.io/posts/3075405)

## 対応案
- 以下のDiscussionで対応案を検討していました
  - https://github.com/kufu/yosegi/discussions/2292
- 検討の結果、SmarthrProviderにオプショナルな引数を追加し、それがtrueだった場合に`email`に`uuid()`を一意のidとして詰める、という対応でどうじゃろかと思っています...！
  - 検討の詳細はDiscussionに書いています
- 1/11のフロントエンド定例でも共有し、概ね良さそうという反応をもらってます
  - 議事録: https://smarthr-inc.docbase.io/posts/3247534#smarthrprovider%E3%81%AB%E9%9D%9E%E7%A0%B4%E5%A3%8A%E3%81%AA%E5%A4%89%E6%9B%B4%E3%82%92%E3%81%84%E3%82%8C%E3%81%9F%E3%81%84ytaka
  - Slack: https://kufuinc.slack.com/archives/CJEUZ4MS6/p1704956527415999

## 動作確認方法
localのyosegiにて動作確認しているため、reviewerの方に再度確認はしていただかなくても大丈夫かと思ってます！
動作確認を行った手順を残しておきます。

- localで利用するSmarthrProviderを今回の実装に差し替え、`useUuidForEmail` オプションを有効にする
- メールアドレスAのアカウントでyosegiにアクセスする
- hanicaの個人設定から、メールアドレスAをメールアドレスBに変更する
- 使われなくなったメールアドレスAで、別のアカウントを招待する
- 招待されたアカウントでyosegiにログインできることを確認
  - 以前はここで `OAuthAccountNotLinked` エラーになっていました

## 見てほしい点
- 方針に違和感がないかどうか