### PR TITLE
node 16.xをテスト対象外にし、20.xをテスト対象に追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   build:
-    name: Node.js ubuntu-latest 18.x
+    name: Node.js ubuntu-latest 20.x
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 18.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 20.x
     - name: yarn install, and yarn lint
       run: |
         yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
## やりたいこと

tamatebakoでテストに使っているnodeのバージョンが16.xと18.xだったのですが、すでに16.xはメンテナンスが終了してサポート対象外になっているので修正したい

https://nodejs.org/en/about/previous-releases

## やったこと

ACTIVEの20.xと、MAINTENANCEの18.xで `test` と `lint` の CI が動くようにしました。