### PR TITLE
パッケージの情報が古いため、create-lint-set が動作しなくなっている問題を修正

### DIFF
--- a/packages/create-lint-set/src/items.ts
+++ b/packages/create-lint-set/src/items.ts
@@ -25,12 +25,10 @@ export const items: Item[] = [
     templateDirName: 'stylelint',
     packages: [
       'stylelint',
-      'stylelint-config-prettier',
       'stylelint-config-smarthr',
       'stylelint-config-standard',
       'stylelint-config-styled-components',
-      'postcss-jsx',
-      'postcss-syntax',
+      'postcss-styled-syntax'
     ],
     configFilePattern: /\.stylelintrc.*?/,
     npmScriptsSample: '"stylelint": "stylelint \'./**/*.ts{,x}\'',


### PR DESCRIPTION
`npx @smarthr/create-lint-set` を実行するとエラーとなります。

```
% npx @smarthr/create-lint-set
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: xxx@1.0.0
npm error Found: stylelint@14.16.1
npm error node_modules/stylelint
npm error   dev stylelint@"*" from the root project
npm error   peer stylelint@">= 11.x < 15" from stylelint-config-prettier@9.0.5
npm error   node_modules/stylelint-config-prettier
npm error     dev stylelint-config-prettier@"*" from the root project
npm error
npm error Could not resolve dependency:
npm error dev stylelint-config-smarthr@"*" from the root project
npm error
npm error Conflicting peer dependency: stylelint@16.7.0
npm error node_modules/stylelint
npm error   peer stylelint@"^16.0.0" from stylelint-config-smarthr@3.0.1
npm error   node_modules/stylelint-config-smarthr
npm error     dev stylelint-config-smarthr@"*" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```

確認したところ、パッケージの組み合わせが古いようです。（参考： https://github.com/kufu/stylelint-config-smarthr/pull/205 ）

動作するよう対象のパッケージ一覧を修正しました。