### PR TITLE
NextAuthがRedisに保存する認証情報に有効期限を設定したい

### DIFF
--- a/packages/next-auth/src/RedisAdapter.ts
+++ b/packages/next-auth/src/RedisAdapter.ts
@@ -54,12 +54,10 @@ function hydrateDates(jsonStr: string) {
 
 export function RedisAdapter(redis: Redis): Adapter {
   const set = async (key: string, value: string | number) => {
-    await redis.set(key, value)
-    await redis.expire(key, expireSec)
+    await redis.setex(key, expireSec, value)
   }
   const setObjectAsJson = async (key: string, obj: any) => {
-    await redis.set(key, JSON.stringify(obj))
-    await redis.expire(key, expireSec)
+    await redis.setex(key, expireSec, JSON.stringify(obj))
   }
 
   const setAccount = async (id: string, account: AdapterAccount) => {


### PR DESCRIPTION
## WHY

- Redisデータの有効期限 (TTL) はデフォルトだと無期限のため、オプション機能でログインすると明示的に削除しない限り永久にユーザ情報が残る
- 基本機能から発行されたアクセストークンは7日間で失効する仕組みなので、意味のないデータが溜まる状態になっていそう

## WHAT

- 固定値で7日間を期限として設定しました

## HOW

- 書き込みの後処理としてTTLの設定を追加しています
- RedisにはグローバルなTTLを設定する機構がないので、個別の書き込みすべてに適用しています
- 個別に異なる期限を設定したいケースが思いつかなかったので呼び出し側 (アプリ) で値を上書きするような機構は設けておりません

## etc

- 有効期限を保持するためにメモリ使用量が若干増えるらしいです…がデータ保存に比べれば誤差の範疇だと思います

## What to Review

コードレビューのみで大丈夫だと思います

- 書き込み処理すべてにTTLが指定されていること
    - (= `Redis.set` ではなく独自実装の `set` が使われていること)
- 認証時のデータフローを変えてしまう差分がないこと