### PR TITLE
chore: https://github.com/kufu/prettier-config-smarthr からファイルを移動

### DIFF
--- a/packages/prettier-config-smarthr/CHANGELOG.md
+++ b/packages/prettier-config-smarthr/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## [1.0.0](https://github.com/kufu/prettier-config-smarthr/compare/v0.1.0...v1.0.0) (2020-10-27)
+
+## 0.1.0 (2020-10-16)
+
+
+### Features
+
+* add standard-version to release ([7367d2e](https://github.com/kufu/prettier-config-smarthr/commit/7367d2e9d7634581c623da117557fdc2f871f623))

--- a/packages/prettier-config-smarthr/LICENSE
+++ b/packages/prettier-config-smarthr/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright 2023 SmartHR, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/prettier-config-smarthr/README.md
+++ b/packages/prettier-config-smarthr/README.md
@@ -1,0 +1,45 @@
+# prettier-config-smarthr
+
+A sharable prettier config for SmartHR.
+
+## Installation
+
+prettier-config-smarthr is available as an  [npm package](https://www.npmjs.com/package/prettier-config-smarthr).
+
+```sh
+// with npm
+npm install --save-dev prettier-config-smarthr
+
+// with yarn
+yarn add --dev prettier-config-smarthr
+```
+
+## How to use
+
+Edit `package.json`.
+
+```json
+{
+  "name": "your project",
+  "prettier": "prettier-config-smarthr"
+}
+```
+
+If you don’t want to use `package.json`, you can use any of the supported extensions to export a string, e.g. `.prettierrc.json`:
+
+```
+"prettier-config-smarthr"
+```
+
+Check here for details : https://prettier.io/docs/en/configuration.html
+
+### How to extend
+
+Create `.prettierrc.js` , import the file in a `.prettierrc.js` file and export the modifications.
+
+```js
+module.exports = {
+  ...require("prettier-config-smarthr"),
+  "arrowParens": "avoid",
+};
+```

--- a/packages/prettier-config-smarthr/index.json
+++ b/packages/prettier-config-smarthr/index.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": false,
+  "printWidth": 130
+}

--- a/packages/prettier-config-smarthr/package.json
+++ b/packages/prettier-config-smarthr/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "prettier-config-smarthr",
+  "version": "1.0.0",
+  "description": "A sharable prettier config for SmartHR",
+  "main": "index.json",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kufu/tamatebako.git",
+    "directory": "packages/prettier-config-smarthr"
+  },
+  "homepage": "https://github.com/kufu/tamatebako/packages/prettier-config-smarthr#readme",
+  "bugs": {
+    "url": "https://github.com/kufu/tamatebako/issues"
+  },
+  "keywords": [
+    "prettier"
+  ],
+  "author": "SmartHR",
+  "license": "MIT"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,8 @@ importers:
         specifier: ^4.24.7
         version: 4.24.7(next@14.2.16(@babel/core@7.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
+  packages/prettier-config-smarthr: {}
+
   packages/use-bulk-check:
     devDependencies:
       '@testing-library/react-hooks':


### PR DESCRIPTION
## やったこと

https://github.com/kufu/prettier-config-smarthr のリポジトリは閉じて、tamatebako 上で管理する方針になったのでファイルを移動しました。

リポジトリの変更に伴って package.json の記述を一部[もとのファイル](https://github.com/kufu/prettier-config-smarthr/blob/main/package.json)から変更しています。(パスの変更や、devDependencies の削除など)

このプルリクがマージされたら、https://github.com/kufu/prettier-config-smarthr のリポジトリに関しては README.md に管理が tamatebako になった旨を記載したうえでアーカイブする予定です。