### PR TITLE
chore: npm コマンド周りで気になったところを改善した

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ This repository is a monorepo using Lerna and Yarn Workspaces.
 ### Develop
 
 ```sh
-% pnpm start
+% pnpm dev
 ```
 
 ### Test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Frontend packages for projects at SmartHR",
   "main": "index.js",
   "scripts": {
-    "start": "pnpm build --watch",
+    "dev": "pnpm build --watch",
     "build": "lerna run prebuild --stream && pnpm tsc",
     "pretest": "pnpm build",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main": "index.js",
   "scripts": {
     "start": "pnpm build --watch",
-    "prebuild": "lerna run clean --stream",
     "build": "lerna run prebuild --stream && pnpm tsc",
     "pretest": "pnpm build",
     "test": "jest",

--- a/packages/create-lint-set/package.json
+++ b/packages/create-lint-set/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "prebuild": "pnpm copy-templates",
+    "prebuild": "pnpm clean && pnpm copy-templates",
     "copy-templates": "mkdir lib && cp -r src/templates lib/templates",
     "clean": "rimraf lib"
   },

--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -22,6 +22,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "pnpm clean",
     "clean": "rimraf lib"
   },
   "directories": {

--- a/packages/use-bulk-check/package.json
+++ b/packages/use-bulk-check/package.json
@@ -22,6 +22,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "pnpm clean",
     "clean": "rimraf lib"
   },
   "peerDependencies": {

--- a/packages/use-virtual-scroll/package.json
+++ b/packages/use-virtual-scroll/package.json
@@ -22,6 +22,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "pnpm clean",
     "clean": "rimraf lib",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/packages/wareki/package.json
+++ b/packages/wareki/package.json
@@ -22,6 +22,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "pnpm clean",
     "clean": "rimraf lib"
   }
 }


### PR DESCRIPTION
## やったこと

- ルートの package.json から`prerelease` コマンドを削除して、各パッケージに `prerelease` コマンドを追加した
  - 理由は、ルートの package.json から`prerelease` コマンドを実行するタイミングが明示されていないわりに、これを実行しないと `build` を実行したときに (lib ディレクトリが既に存在するなどの理由で) 失敗するパッケージが存在していたからです。
  - `build` を実行するタイミングで `prerelease` がやっていたことと同じことを実行するように変更して、常に `build` コマンドが成功するようにしました。
- ルートの `start` コマンドを `dev` コマンドの変更した
  - 理由は、SmartHR 社のプロダクト・ライブラリでは基本的にこういったコマンドには `dev` を割り当てることが慣習になっているからです。