### PR TITLE
chore: please-release でリリースできるようにした

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release_please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      releases_created: ${{ steps.release_please.outputs.releases_created }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release_please
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: release_please
+    if: ${{ needs.release_please.outputs.releases_created == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm release --no-push --no-private --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,4 @@ jobs:
       - run: pnpm install
       - run: pnpm release --no-push --no-private --yes
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.KUFU_NPM_RELEASE_TOKEN }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,9 @@
+{
+  "packages/create-lint-set": "1.1.5",
+  "packages/next-auth": "0.1.5",
+  "packages/prettier-config-smarthr": "1.0.1",
+  "packages/stylelint-config-smarthr": "3.0.2",
+  "packages/use-bulk-check": "1.0.7",
+  "packages/use-virtual-scroll": "1.1.6",
+  "packages/wareki": "1.3.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "32268ddecb4340a1311b869f09888085e5c12502",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "packages": {
+    "packages/create-lint-set": {},
+    "packages/next-auth": {},
+    "packages/prettier-config-smarthr": {},
+    "packages/stylelint-config-smarthr": {},
+    "packages/use-bulk-check": {},
+    "packages/use-virtual-scroll": {},
+    "packages/wareki": {}
+  }
+}


### PR DESCRIPTION
## 現状の課題

現状のリリースフローは手元で pnpm version を実行した後 pnpm publish を実行するというものですが、この運用には下記のような課題があるかなと思います。

- リリースされるものがなにか分かりづらい
  - 今回のリリースで何がリリース対象になるのかは、pnpm version を実行して changelog を生成するまではコミットやプルリクを追わないといけなく、直感的に知る方法がない
- npm に publish する権限がないとリリースできない
  - リリースしたい場合は npm の SmartHR の organization に追加してもらう必要があります
- リリースのために手元でコマンドを実行するのがシンプルに面倒

これらの問題によって、なんとなく tamatebako が触りづらい気持ちになり、メンテナンスが滞りがちなところがあると思っています。

## こうしたい

release-please という github actions を使うと、下記のような運用になるので、上記の課題が解決されます。

- プルリクがマージされると conventional commits の内容に応じてリリース用のプルリクが作成される
- そのプルリクの description を見てリリース内容を確認する
- そのプルリクをマージすることでリリースが行われる

リリースされるものがわかりやすい & リリースしやすい仕組みになるので、幸せになれる気がしています！

## 具体的な挙動

リポジトリを fork して具体的な挙動を確かめています 👇 

まずはこのプルリクとほぼ同じ内容のものをマージしました。(publish 部分だけ実行されないように書き換えています)
https://github.com/Tokky0425/tamatebako/pull/1

次に、`fix!` の prefix を含んだコミットを作ってプルリクを作り、マージをしました。
https://github.com/Tokky0425/tamatebako/pull/2

この段階で、下記の release という action が実行されます。
https://github.com/Tokky0425/tamatebako/actions/runs/12254213043

この action によって自動で作成されたプルリクがこれです。
いい感じに description 部分にリリース内容が表示されていることがわかります。
https://github.com/Tokky0425/tamatebako/pull/3

このリリースプルリクをマージした結果、再び release の action が実行されます。
https://github.com/Tokky0425/tamatebako/actions/runs/12254230789
release-please によって作成されたプルリクがマージされた場合、releases_created が true になり、publish のステップが実行されることになります。

また、マージ後はタグもちゃんと作成されています。
https://github.com/Tokky0425/tamatebako/releases/tag/create-lint-set-v2.0.0

## 参考
lerna を使ったモノレポの設定例。`--no-push --no-private --yes` のオプションはこれを参考にしています。
https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#using-with-github-actions-and-lerna
現状 lerna は conventional commit から changelog を作ったりタグを打ったりという役割を果たしていますが、release-please にその役割が移る形になるのでそもそも lerna 卒業で良さそうかな〜と思っています。