### PR TITLE
feat: a11y-input-in-form-controlでtype="hidden"の場合の判定を追加

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/a11y-input-in-form-control/index.js
+++ b/packages/eslint-plugin-smarthr/rules/a11y-input-in-form-control/index.js
@@ -143,6 +143,9 @@ module.exports = {
                       case 'checkbox':
                         isTypeCheck = true
                         break
+                      case 'hidden':
+                        // HINT: hiddenの場合はラベルなしを許容するため、breakではなくreturnで処理終了させる
+                        return
                     }
 
                     break

--- a/packages/eslint-plugin-smarthr/test/a11y-input-in-form-control.js
+++ b/packages/eslint-plugin-smarthr/test/a11y-input-in-form-control.js
@@ -90,6 +90,7 @@ ruleTester.run('a11y-input-in-form-control', rule, {
     { code: 'const HogeRadioButtonPanel = styled(FugaRadioButtonPanel)``' },
     { code: 'const HogeCheckBox = styled(FugaCheckbox)``' },
     { code: 'const DatePicker = styled(AnyDatePicker)``' },
+    { code: '<input type="hidden" />' },
     { code: '<input title="any"/>' },
     { code: '<HogeInput title="any"/>' },
     { code: '<textarea title="any"/>' },


### PR DESCRIPTION
- type="hidden" が指定されている場合の対応を追加します
- hiddenの場合、labelは不要なため必須判定から除外します