### PR TITLE
chore: setup-node 時に registry-url の指定を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
       - run: pnpm install
       - run: pnpm release --no-push --no-private --yes
         env:


### PR DESCRIPTION
[リリースでコケた](https://github.com/kufu/tamatebako/actions/runs/12664241504/job/35292061540)のでそれの修正対応です。

[npmレジストリへのパッケージの公開](https://docs.github.com/ja/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) に書いてある

> 資格情報を適切に構成するには、setup-node で registry-url を https://registry.npmjs.org/ に設定する必要があることに注意してください。

が反映されていないのが原因なのではないかなと思っています。

`registry-url` があると、

```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
registry=https://registry.npmjs.org/
```

の記述が含まれる .npmrc を作成してくれるようです。
実装: https://github.com/actions/setup-node/blob/48b90677b6048efbc723b11a94acb950d3f1ac36/src/main.ts#L58-L60