### PR TITLE
feat(eslint-config-smarthr)!: react 17+以降のルールに対応した

### DIFF
--- a/packages/eslint-config-smarthr/configs/eslint.js
+++ b/packages/eslint-config-smarthr/configs/eslint.js
@@ -131,6 +131,19 @@ export default [
       'vars-on-top': 'warn',
       'wrap-iife': ['error', 'any'],
       'yield-star-spacing': ['error', 'after'],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              // `import React from 'react';` を禁止する
+              name: 'react',
+              importNames: ['default'],
+              message: 'React 17+ では default import は不要なので削除してください。',
+            },
+          ],
+        },
+      ],
     },
   }
 ]

--- a/packages/eslint-config-smarthr/configs/react.js
+++ b/packages/eslint-config-smarthr/configs/react.js
@@ -20,8 +20,10 @@ export default [
     languageOptions: {
       parserOptions: {
         ecmaFeatures: {
-          jax: true,
+          jsx: true,
         },
+        // https://github.com/jsx-eslint/eslint-plugin-react/blob/e6b5b41191690ee166d0cca1e9db27092b910f03/index.js#L86
+        jsxPragma: null, // for @typescript/eslint-parser
       },
     },
     settings: {
@@ -82,6 +84,9 @@ export default [
       'react/prop-types': 'off',
       'react/style-prop-object': 'error',
       'react/void-dom-elements-no-children': 'error',
+      // https://github.com/jsx-eslint/eslint-plugin-react/blob/e6b5b41191690ee166d0cca1e9db27092b910f03/index.js#L89
+      'react/react-in-jsx-scope': 'off',
+      'react/jsx-uses-react': 'off'
     }
   }
 ]

--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "test": "vitest run",
-    "test:update-snapshot": "vitest --updateSnapshot"
+    "test:update-snapshot": "vitest -u"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
@@ -1906,6 +1906,20 @@ exports[`should match ESLint Configuration snapshot 1`] = `
     "no-reserved-keys": [
       0,
     ],
+    "no-restricted-imports": [
+      2,
+      {
+        "paths": [
+          {
+            "importNames": [
+              "default",
+            ],
+            "message": "React 17+ では default import は不要なので削除してください。",
+            "name": "react",
+          },
+        ],
+      },
+    ],
     "no-return-assign": [
       2,
       "except-parens",

--- a/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
@@ -1193,10 +1193,10 @@ exports[`should match ESLint Configuration snapshot 1`] = `
     "parser": "typescript-eslint/parser@8.19.1",
     "parserOptions": {
       "ecmaFeatures": {
-        "jax": true,
         "jsx": true,
       },
       "ecmaVersion": 2018,
+      "jsxPragma": null,
       "sourceType": "module",
     },
     "sourceType": "module",
@@ -2212,7 +2212,7 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       0,
     ],
     "react/jsx-uses-react": [
-      2,
+      0,
     ],
     "react/jsx-uses-vars": [
       2,
@@ -2287,7 +2287,7 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       0,
     ],
     "react/react-in-jsx-scope": [
-      2,
+      0,
     ],
     "react/require-render-return": [
       2,


### PR DESCRIPTION
## やりたいこと

- react 17+以降のeslintルールに対応し、不要なルールをOFFにしたいです。

## やったこと

- 以下のルールがデフォルトでエラーからOFFにした。
  - [react/jsx-uses-react](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md)
  - [react/react-in-jsx-scope](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md)
- `import React from 'react';` のようにデフォルトインポートを使った場合はエラーになるようにした。
  - ref: https://github.com/kufu/tamatebako/pull/499#discussion_r1936598772

## 背景

react 17以前は `import React from 'react'` の記述が必須でした。実際、eslint-plugin-reactでは [react/react-in-jsx-scope](https://github.com/jsx-eslint/eslint-plugin-react/blob/e6b5b41191690ee166d0cca1e9db27092b910f03/docs/rules/react-in-jsx-scope.md)のルールがデフォルトでONです。
[react 17以降は `import React from 'react'` の記述が不要](https://ja.legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)となり、[react 17+用の設定があるので適用](https://github.com/jsx-eslint/eslint-plugin-react/?tab=readme-ov-file#flat-configs:~:text=flat.recommended-,flat%5B%27jsx%2Druntime%27%5D,-The%20flat%20configs)しました。
これにより、各プロダクトで設定している `'react/react-in-jsx-scope': 'off'` や `'react/jsx-uses-react': 'off'` の記述が不要になります。
また、私の調べた限りでは各プロダクトreact 17より上っぽいので大丈夫だと思います。