### PR TITLE
ci: publishに失敗しないようにcorepackの有効化方法を変えた

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ needs.release_please.outputs.releases_created == 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm install -g corepack@latest
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
[corepack起因](https://github.com/nodejs/corepack/issues/612)でnpmへの[publishに失敗](https://github.com/kufu/tamatebako/actions/runs/13126270687/job/36623133718)していた問題へ対応しました。
