### PR TITLE
:bug: profile に role が含まれていなかったので role.session_timeout_in を追加

### DIFF
--- a/packages/next-auth/src/SmarthrProvider.ts
+++ b/packages/next-auth/src/SmarthrProvider.ts
@@ -54,8 +54,11 @@ export const SmarthrProvider = ({ smarthrUrl, redirectUri, clientId, clientSecre
       id: profile.id,
       // email の重複による OAuthAccountNotLinked エラー避けるため、useUuidForEmail が true の場合は uuid を email として扱う
       // 社員番号ログインで email がない場合も uuid を代わりとする
-      email: useUuidForEmail ? uuid() : profile.email ?? uuid(),
+      email: useUuidForEmail ? uuid() : (profile.email ?? uuid()),
       uid: profile.id,
+      role: {
+        session_timeout_in: profile.role?.session_timeout_in ?? null,
+      },
     }
   },
 })


### PR DESCRIPTION
## 経緯

`@smarthr/next-auth` を使用しているプラスアプリでは、ログイン時に渡される profile の role.session_timeout_in を redis の expire に設定することで、SmartHR で設定している権限のタイムアウトの設定をプラスアプリ側でも引き継ぐ実装になっています。

しかし、`@smarthr/next-auth` 側で profile に role を渡していなかったため、プラスアプリ側で role.session_timeout_in が取得できておらず、タイムアウトの設定が引き継がれない状態になってしまっていました。

直したい。