### PR TITLE
chore: プルリクタイトルが conventional commits に従っているかをチェックするようにした

### DIFF
--- a/.github/workflows/titleCheck.yml
+++ b/.github/workflows/titleCheck.yml
@@ -1,0 +1,23 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  conventional_commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          regex="^(feat|fix|docs|chore|style|refactor|perf|test)(\([^\)]+\))?!?:[[:space:]].+"
+          if [[ "$PR_TITLE" =~ $regex ]]; then
+              echo OK
+          else
+              echo "::error::Pull Request のタイトルが Conventional Commits 形式にマッチしません"
+              exit 1
+          fi


### PR DESCRIPTION
smarthr-ui で導入されているもの 👇  をほぼそのまま持ってきました (if 条件の部分だけ不要なので削除しています)
https://github.com/kufu/smarthr-ui/blob/1c9462425518d2628061279ea737d3cdd610e342/.github/workflows/titleCheck.yml

このプルリク上で、`chore:` をタイトルから消すと CI が落ちることを確認済みです 👁️ 