### PR TITLE
feat: smarthr/best-practice-for-async-current-target を有効にする

### DIFF
--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -48,6 +48,7 @@ export default [
       'smarthr/a11y-prohibit-useless-sectioning-fragment': 'error',
       'smarthr/a11y-replace-unreadable-symbol': 'error',
       'smarthr/a11y-trigger-has-button': 'error',
+      'smarthr/best-practice-for-async-current-target': 'error',
       'smarthr/best-practice-for-button-element': 'error',
       'smarthr/best-practice-for-date': 'error',
       'smarthr/best-practice-for-layouts': 'error',
@@ -66,5 +67,6 @@ export default [
       'smarthr/require-import': 'off',
       'smarthr/trim-props': 'error',
     }
+
   }
 ]

--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "eslint-plugin-smarthr": "1.5.1",
+    "eslint-plugin-smarthr": "1.6.0",
     "globals": "^16.1.0",
     "typescript-eslint": "^8.32.1"
   }

--- a/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
@@ -2975,6 +2975,9 @@ exports[`should match ESLint Configuration snapshot 1`] = `
     "smarthr/a11y-trigger-has-button": [
       2,
     ],
+    "smarthr/best-practice-for-async-current-target": [
+      2,
+    ],
     "smarthr/best-practice-for-button-element": [
       2,
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 1.5.1
-        version: 1.5.1(eslint@9.27.0(jiti@2.4.2))
+        specifier: 1.6.0
+        version: 1.6.0(eslint@9.27.0(jiti@2.4.2))
       globals:
         specifier: ^16.1.0
         version: 16.1.0
@@ -3240,6 +3240,12 @@ packages:
   eslint-plugin-smarthr@1.5.1:
     resolution: {integrity: sha512-ALV8KApTyzc1+bE41vlJdybiYfusLpujzSy4hzEatZHvLFq2+KnJyFJ4RZ7ePiBoht064qaK428HwzwjRKf46A==}
     engines: {node: '>=22.15.0'}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@1.6.0:
+    resolution: {integrity: sha512-D2Gjn6OslkBpG1EvjeoTr3ktaSy7O6OEcuy8+xGx/HWiLT96pyoq0qWJcHu38rCNil2ECSmaWtlIzWjsCsNjcA==}
+    engines: {node: '>=22.15.1'}
     peerDependencies:
       eslint: ^9
 
@@ -10185,6 +10191,11 @@ snapshots:
       string.prototype.repeat: 1.0.0
 
   eslint-plugin-smarthr@1.5.1(eslint@9.27.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.27.0(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@1.6.0(eslint@9.27.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.27.0(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
- イベントハンドラ外からのe.currentTarget参照を避けるルールを有効化します
  - このチェックの対象となるコードは、ランダムで成否が変わり気づきにくいため