### PR TITLE
fix: a11y-anchor-has-href-attribute での特殊分岐条件を react-router-dom から react-router に変更

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/a11y-anchor-has-href-attribute/index.js
+++ b/packages/eslint-plugin-smarthr/rules/a11y-anchor-has-href-attribute/index.js
@@ -31,7 +31,7 @@ const OPTION = (() => {
         }
 
         break
-      case 'react-router-dom':
+      case 'react-router':
         react_router = true
 
         if (nextjs) {


### PR DESCRIPTION
a11y-anchor-has-href-attribute のルールでは package.json に react-router-dom があれば `href` ではなく `to` があることを検証するような処理になっていますが、React Router は v7 から react-router-dom のパッケージを必要としなくなっているので、この判定が正しく効かない状態になっています。そのため、react-router の有無によって判別をするコードに変更しました。(v6 以前の場合でも、react-router の有無による判別で問題ないので、react-router-dom による判定は削除しています)