### PR TITLE
feat: 最新の eslint-plugin-smarthr に追従

### DIFF
--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "eslint-plugin-smarthr": "1.8.0",
+    "eslint-plugin-smarthr": "1.8.1",
     "globals": "^16.2.0",
     "typescript-eslint": "^8.33.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 1.8.0
-        version: 1.8.0(eslint@9.28.0(jiti@2.4.2))
+        specifier: 1.8.1
+        version: 1.8.1(eslint@9.28.0(jiti@2.4.2))
       globals:
         specifier: ^16.2.0
         version: 16.2.0
@@ -3451,8 +3451,8 @@ packages:
     peerDependencies:
       eslint: ^9
 
-  eslint-plugin-smarthr@1.8.0:
-    resolution: {integrity: sha512-Ix80vJKcnXgbPicX/d3GO5OOkNM6Of9mPPNp8yoLfz+7TPex3bOZPRo6nLOjtj2qiaTON0DX9658F2L96m2imQ==}
+  eslint-plugin-smarthr@1.8.1:
+    resolution: {integrity: sha512-XyIbfhY7P/6ovQ+bjUOJwlFnW1rV6vh5pjEiko23iwrcTiOdv20pNWEZGRVB8z6oc08XvIbkkU/gaJJLHN9oJQ==}
     engines: {node: '>=22.16.0'}
     peerDependencies:
       eslint: ^9
@@ -5367,10 +5367,6 @@ packages:
   pify@5.0.0:
     resolution: {integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==}
     engines: {node: '>=10'}
-
-  pirates@4.0.6:
-    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
-    engines: {node: '>= 6'}
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -8113,7 +8109,7 @@ snapshots:
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       micromatch: 4.0.8
-      pirates: 4.0.6
+      pirates: 4.0.7
       slash: 3.0.0
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
@@ -10677,7 +10673,7 @@ snapshots:
       eslint: 9.28.0(jiti@2.4.2)
       json5: 2.2.3
 
-  eslint-plugin-smarthr@1.8.0(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-smarthr@1.8.1(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.28.0(jiti@2.4.2)
       json5: 2.2.3
@@ -11646,7 +11642,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.27.4
-      '@babel/parser': 7.27.4
+      '@babel/parser': 7.27.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -13074,9 +13070,6 @@ snapshots:
   pify@4.0.1: {}
 
   pify@5.0.0: {}
-
-  pirates@4.0.6:
-    optional: true
 
   pirates@4.0.7: {}
 


### PR DESCRIPTION
## 今回のアプデに入ったもの

- eslint-plugin-smarthr v1.8.1
  - https://github.com/kufu/tamatebako/releases/tag/eslint-plugin-smarthr-v1.8.1
- eslint-plugin-smarthr v1.8.0
  - https://github.com/kufu/tamatebako/releases/tag/eslint-plugin-smarthr-v1.8.0