### PR TITLE
feat: getLocaleの一部の判定をサーバサイドでも利用可能にした

### DIFF
--- a/packages/i18n/src/get-locale/getLocale.node.test.ts
+++ b/packages/i18n/src/get-locale/getLocale.node.test.ts
@@ -4,7 +4,6 @@
 import { type Locale, getLocale } from './getLocale'
 
 describe('getLocale (node環境)', () => {
-  // 共通のlocales配列を使用することを提案
   const supportedLocales: Locale[] = ['en-US', 'ja-JP', 'ko-KR']
 
   describe('shouldReturnDefaultLanguage が true の場合', () => {

--- a/packages/i18n/src/get-locale/getLocale.node.test.ts
+++ b/packages/i18n/src/get-locale/getLocale.node.test.ts
@@ -1,15 +1,51 @@
 /**
  * @jest-environment node
  */
-import { getLocale } from './getLocale'
+import { type Locale, getLocale } from './getLocale'
 
 describe('getLocale (node環境)', () => {
-  it('ブラウザ環境ではない場合、デフォルトの言語コードを返す', () => {
-    const result = getLocale({
-      currentLocale: 'en-US',
-      supportedLocales: ['en-US', 'ja-JP'],
-      shouldReturnDefaultLanguage: false,
+  // 共通のlocales配列を使用することを提案
+  const supportedLocales: Locale[] = ['en-US', 'ja-JP', 'ko-KR']
+
+  describe('shouldReturnDefaultLanguage が true の場合', () => {
+    it('デフォルトの言語コード（ja-JP）を返すこと', () => {
+      expect(
+        getLocale({
+          currentLocale: 'en-US',
+          supportedLocales,
+          shouldReturnDefaultLanguage: true,
+        }),
+      ).toBe('ja-JP')
     })
-    expect(result).toBe('ja-JP')
+  })
+  describe('locale が null の場合', () => {
+    it('デフォルトの言語コード（ja-JP）を返すこと', () => {
+      expect(
+        getLocale({
+          currentLocale: null,
+          supportedLocales,
+        }),
+      ).toBe('ja-JP')
+    })
+  })
+  describe('locale で指定された言語コードにアプリが対応している場合', () => {
+    it('指定された言語コードを返すこと', () => {
+      expect(
+        getLocale({
+          currentLocale: 'en-US',
+          supportedLocales,
+        }),
+      ).toBe('en-US')
+    })
+  })
+  describe('ブラウザ環境ではなく locale で指定された言語コードにアプリが対応していない場合', () => {
+    it('デフォルトの言語コード（ja-JP）を返すこと', () => {
+      const result = getLocale({
+        currentLocale: 'vi-VN',
+        supportedLocales,
+        shouldReturnDefaultLanguage: false,
+      })
+      expect(result).toBe('ja-JP')
+    })
   })
 })

--- a/packages/i18n/src/get-locale/getLocale.ts
+++ b/packages/i18n/src/get-locale/getLocale.ts
@@ -2,7 +2,7 @@ const DEFAULT_LANGUAGE = 'ja-JP'
 
 /**
  * サポートされているロケール一覧：
- * 
+ *
  * ja-JP: 日本語
  * en-US: 英語
  * ko-KR: 韓国語
@@ -39,15 +39,15 @@ export function getLocale(params: {
 }): Locale {
   const { currentLocale, supportedLocales, shouldReturnDefaultLanguage = false, cookieKey = 'selectedLocale' } = params
 
-  // サーバーサイドのエラー回避
-  if (typeof window === 'undefined') return DEFAULT_LANGUAGE
-
   // デフォルト言語を返すべき場合
   if (shouldReturnDefaultLanguage) return DEFAULT_LANGUAGE
 
   if (currentLocale === null) return DEFAULT_LANGUAGE
 
   if (supportedLocales.includes(currentLocale)) return currentLocale
+
+  // サーバーサイドのエラー回避
+  if (typeof window === 'undefined') return DEFAULT_LANGUAGE
 
   // cookieから言語コードを取得
   const cookieLocale = getCookieLocale(cookieKey)

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,4 +1,4 @@
-export { getLocale } from './get-locale/getLocale'
+export { type Locale, getLocale } from './get-locale/getLocale'
 export { useIntl } from './use-intl/useIntl'
 export { useNextIntl } from './use-intl/useNextIntl'
 export { useIntlImpl } from './use-intl/useIntlImpl'


### PR DESCRIPTION
## やったこと

getLocaleをサーバサイドで使った場合に、アプリケーションが対応しているロケールであれば利用可能（変更前は必ずデフォルトロケールになる仕様）に変更しました。
cookieやブラウザの言語設定からの取得は非対応のままとしています。
