### PR TITLE
feat: a11y-input-form-controlのラベル設定チェックのロジックを変更する

### DIFF
--- a/packages/eslint-plugin-smarthr/test/a11y-input-in-form-control.js
+++ b/packages/eslint-plugin-smarthr/test/a11y-input-in-form-control.js
@@ -12,16 +12,16 @@ const ruleTester = new RuleTester({
 })
 const noLabeledInput = (name) => `${name} を、smarthr-ui/FormControl もしくはそれを拡張したコンポーネントが囲むようマークアップを変更してください。
  - FormControlで入力要素を囲むことでラベルと入力要素が適切に紐づき、操作性が高まります
+   - 画面上に表示するラベルが存在しない場合でも、必ずその入力要素は何であるか、どんな値を入力すればいいのか？を伝えるため、ラベルの設定は必須です。
+     - この場合、FormControlのdangerouslyTitleHidden属性をtrueにして、ラベルを非表示にしてください(https://smarthr.design/products/components/form-control/)
  - ${name}が入力要素とラベル・タイトル・説明など含む概念を表示するコンポーネントの場合、コンポーネント名を/(Form(Control|Group)|(F|^f)ieldset)$/とマッチするように修正してください
- - ${name}が入力要素自体を表現するコンポーネントの一部である場合、ルートとなるコンポーネントの名称を/(RadioButton(Panel)?(s)?|Check(B|b)ox(es|s)?|(Search)?(I|^i)nput(File)?|(T|^t)extarea|(S|^s)elect|Combo(B|b)ox|(Date|Wareki|Time)Picker)$/とマッチするように修正してください
- - 上記のいずれの方法も適切ではない場合、${name}のtitle属性に "どんな値を入力すれば良いのか" の説明を設定してください
-   - 例: <${name} title="姓を全角カタカナのみで入力してください" />`
+ - ${name}が入力要素自体を表現するコンポーネントの一部である場合、ルートとなるコンポーネントの名称を/(RadioButton(Panel)?(s)?|Check(B|b)ox(es|s)?|(Search)?(I|^i)nput(File)?|(T|^t)extarea|(S|^s)elect|Combo(B|b)ox|(Date|Wareki|Time)Picker)$/とマッチするように修正してください`
 const noLabeledSelect = (name) => `${name} を、smarthr-ui/FormControl もしくはそれを拡張したコンポーネントが囲むようマークアップを変更してください。
  - FormControlで入力要素を囲むことでラベルと入力要素が適切に紐づき、操作性が高まります
+   - 画面上に表示するラベルが存在しない場合でも、必ずその入力要素は何であるか、どんな値を入力すればいいのか？を伝えるため、ラベルの設定は必須です。
+     - この場合、FormControlのdangerouslyTitleHidden属性をtrueにして、ラベルを非表示にしてください(https://smarthr.design/products/components/form-control/)
  - ${name}が入力要素とラベル・タイトル・説明など含む概念を表示するコンポーネントの場合、コンポーネント名を/(Form(Control|Group)|(F|^f)ieldset)$/とマッチするように修正してください
- - ${name}が入力要素自体を表現するコンポーネントの一部である場合、ルートとなるコンポーネントの名称を/(RadioButton(Panel)?(s)?|Check(B|b)ox(es|s)?|(Search)?(I|^i)nput(File)?|(T|^t)extarea|(S|^s)elect|Combo(B|b)ox|(Date|Wareki|Time)Picker)$/とマッチするように修正してください
- - 上記のいずれの方法も適切ではない場合、${name}のtitle属性に "どんな値を選択すれば良いのか" の説明を設定してください
-   - 例: <${name} title="検索対象を選択してください" />`
+ - ${name}が入力要素自体を表現するコンポーネントの一部である場合、ルートとなるコンポーネントの名称を/(RadioButton(Panel)?(s)?|Check(B|b)ox(es|s)?|(Search)?(I|^i)nput(File)?|(T|^t)extarea|(S|^s)elect|Combo(B|b)ox|(Date|Wareki|Time)Picker)$/とマッチするように修正してください`
 const invalidPureCheckboxInFormControl = (name) => `HogeFormControl が ${name} を含んでいます。smarthr-ui/FormControl を smarthr-ui/Fieldset に変更し、正しくグルーピングされるように修正してください。
  - 可能なら${name}はsmarthr-ui/Checkboxへの変更を検討してください。難しい場合は ${name} と結びつくlabel要素が必ず存在するよう、マークアップする必要があることに注意してください。`
 const invalidCheckboxInFormControl = (name) => `HogeFormControl が ${name} を含んでいます。smarthr-ui/FormControl を smarthr-ui/Fieldset に変更し、正しくグルーピングされるように修正してください。`
@@ -31,42 +31,45 @@ const invalidPureRadioInFormControl = (name) => `HogeFormControl が ${name} を
 const invalidRadioInFormControl = (name) => `HogeFormControl が ${name} を含んでいます。smarthr-ui/FormControl を smarthr-ui/Fieldset に変更し、正しくグルーピングされるように修正してください。
  - Fieldsetで同じname属性のラジオボタン全てを囲むことで正しくグループ化され、適切なタイトル・説明を追加出来ます`
 const invalidMultiInputsInFormControl = () => `HogeFormControl が複数の入力要素を含んでいます。ラベルと入力要素の紐づけが正しく行われない可能性があるため、以下の方法のいずれかで修正してください。
- - 方法1: 入力要素ごとにラベルを設定できる場合、HogeFormControlをsmarthr-ui/Fieldset、もしくはそれを拡張したコンポーネントに変更した上で、入力要素を一つずつsmarthr-ui/FormControlで囲むようにマークアップを変更してください
- - 方法2: 郵便番号や電話番号など、本来一つの概念の入力要素を分割して複数の入力要素にしている場合、一つの入力要素にまとめることを検討してください
+ - 方法1: 郵便番号や電話番号など、本来一つの概念の入力要素を分割して複数の入力要素にしている場合、一つの入力要素にまとめることを検討してください
    - コピーアンドペーストがしやすくなる、ブラウザの自動補完などがより適切に反映されるなど多大なメリットがあります
- - 方法3: HogeFormControl が smarthr-ui/FormControl、もしくはそれを拡張しているコンポーネントではない場合、名称を /(Form(Control|Group)|(F|^f)ieldset)$/ にマッチしないものに変更してください
- - 方法4: 上記方法のいずれも対応出来ない場合、HogeFormControl に 'role="group"' 属性を設定してください`
+ - 方法2: HogeFormControlをsmarthr-ui/Fieldset、もしくはそれを拡張したコンポーネントに変更した上で、入力要素を一つずつsmarthr-ui/FormControlで囲むようにマークアップを変更してください
+   - 画面上に表示するラベルが存在しない場合でも、必ずその入力要素は何であるか、どんな値を入力すればいいのか？を伝えるため、ラベルの設定は必須です。
+     - この場合、FormControlのdangerouslyTitleHidden属性をtrueにして、ラベルを非表示にしてください(https://smarthr.design/products/components/form-control/)
+ - 方法3: HogeFormControl が smarthr-ui/FormControl、もしくはそれを拡張しているコンポーネントではない場合、名称を /(Form(Control|Group)|(F|^f)ieldset)$/ にマッチしないものに変更してください`
 const noLabeledInputInFieldset = (name) => `HogeFieldset が ラベルを持たない入力要素(${name})を含んでいます。入力要素が何であるかを正しく伝えるため、以下の方法のいずれかで修正してください。
  - 方法1: HogeFieldset を smarthr-ui/FormControl、もしくはそれを拡張したコンポーネントに変更してください
+   - 画面上に表示するラベルが存在しない場合でも、必ずその入力要素は何であるか、どんな値を入力すればいいのか？を伝えるため、ラベルの設定は必須です。
+     - この場合、FormControlのdangerouslyTitleHidden属性をtrueにして、ラベルを非表示にしてください(https://smarthr.design/products/components/form-control/)
  - 方法2: ${name} がlabel要素を含むコンポーネントである場合、名称を/(Form(Control|Group))$/にマッチするものに変更してください
    - smarthr-ui/FormControl、smarthr-ui/FormGroup はlabel要素を内包しています
  - 方法3: ${name} がRadioButton、もしくはCheckboxを表すコンポーネントの場合、名称を/(RadioButton(Panel)?(s)?|Check(B|b)ox(es|s)?)$/にマッチするものに変更してください
    - smarthr-ui/RadioButton、smarthr-ui/RadioButtonPanel、smarthr-ui/Checkbox はlabel要素を内包しています
  - 方法4: HogeFieldset が smarthr-ui/Fieldset、もしくはそれを拡張しているコンポーネントではない場合、名称を /Fieldset$/ にマッチしないものに変更してください
- - 方法5: 別途label要素が存在し、それらと紐づけたい場合はlabel要素のhtmlFor属性、${name}のid属性に同じ文字列を指定してください。この文字列はhtml内で一意である必要があります
- - 方法6: 上記のいずれの方法も適切ではない場合、${name}のtitle属性に "どんな値を入力すれば良いのか" の説明を設定してください
-   - 例: <${name} title="姓を全角カタカナのみで入力してください" />`
+ - 方法5: 別途label要素が存在し、それらと紐づけたい場合はlabel要素のhtmlFor属性、${name}のid属性に同じ文字列を指定してください。この文字列はhtml内で一意である必要があります`
 const noLabeledInputInFieldsetWithSelect = (name) => `HogeFieldset が ラベルを持たない入力要素(${name})を含んでいます。入力要素が何であるかを正しく伝えるため、以下の方法のいずれかで修正してください。
  - 方法1: HogeFieldset を smarthr-ui/FormControl、もしくはそれを拡張したコンポーネントに変更してください
+   - 画面上に表示するラベルが存在しない場合でも、必ずその入力要素は何であるか、どんな値を入力すればいいのか？を伝えるため、ラベルの設定は必須です。
+     - この場合、FormControlのdangerouslyTitleHidden属性をtrueにして、ラベルを非表示にしてください(https://smarthr.design/products/components/form-control/)
  - 方法2: ${name} がlabel要素を含むコンポーネントである場合、名称を/(Form(Control|Group))$/にマッチするものに変更してください
    - smarthr-ui/FormControl、smarthr-ui/FormGroup はlabel要素を内包しています
  - 方法3: ${name} がRadioButton、もしくはCheckboxを表すコンポーネントの場合、名称を/(RadioButton(Panel)?(s)?|Check(B|b)ox(es|s)?)$/にマッチするものに変更してください
    - smarthr-ui/RadioButton、smarthr-ui/RadioButtonPanel、smarthr-ui/Checkbox はlabel要素を内包しています
  - 方法4: HogeFieldset が smarthr-ui/Fieldset、もしくはそれを拡張しているコンポーネントではない場合、名称を /Fieldset$/ にマッチしないものに変更してください
- - 方法5: 別途label要素が存在し、それらと紐づけたい場合はlabel要素のhtmlFor属性、${name}のid属性に同じ文字列を指定してください。この文字列はhtml内で一意である必要があります
- - 方法6: 上記のいずれの方法も適切ではない場合、${name}のtitle属性に "どんな値を選択すれば良いのか" の説明を設定してください
-   - 例: <${name} title="検索対象を選択してください" />`
+ - 方法5: 別途label要素が存在し、それらと紐づけたい場合はlabel要素のhtmlFor属性、${name}のid属性に同じ文字列を指定してください。この文字列はhtml内で一意である必要があります`
 const useFormControlInsteadOfSection = (name, section) => `${name}は${section}より先に、smarthr-ui/FormControlが入力要素を囲むようマークアップを以下のいずれかの方法で変更してください。
  - 方法1: ${section} をFormControl、もしくはそれを拡張したコンポーネントに変更してください
    - ${section} 内のHeading要素はFormControlのtitle属性に変更してください
  - 方法2: ${section} と ${name} の間に FormControl が存在するようにマークアップを変更してください
- - 方法3: 別途label要素が存在し、それらと紐づけたい場合はlabel要素のhtmlFor属性、${name}のid属性に同じ文字列を指定してください。この文字列はhtml内で一意である必要があります
- - 方法4: 上記のいずれの方法も適切ではない場合、${name}のtitle属性に "どんな値を入力すれば良いのか" の説明を設定してください
-   - 例: <${name} title="姓を全角カタカナのみで入力してください" />`
+   - 画面上に表示するラベルが存在しない場合でも、必ずその入力要素は何であるか、どんな値を入力すればいいのか？を伝えるため、ラベルの設定は必須です。
+     - この場合、FormControlのdangerouslyTitleHidden属性をtrueにして、ラベルを非表示にしてください(https://smarthr.design/products/components/form-control/)
+ - 方法3: 別途label要素が存在し、それらと紐づけたい場合はlabel要素のhtmlFor属性、${name}のid属性に同じ文字列を指定してください。この文字列はhtml内で一意である必要があります`
 const useFormControlInsteadOfSectionInRadio = (name, section) => `${name}は${section}より先に、smarthr-ui/Fieldsetが入力要素を囲むようマークアップを以下のいずれかの方法で変更してください。
  - 方法1: ${section} をFieldset、もしくはそれを拡張したコンポーネントに変更してください
    - ${section} 内のHeading要素はFieldsetのtitle属性に変更してください
- - 方法2: ${section} と ${name} の間に Fieldset が存在するようにマークアップを変更してください`
+ - 方法2: ${section} と ${name} の間に Fieldset が存在するようにマークアップを変更してください
+   - 画面上に表示するラベルが存在しない場合でも、必ずその入力要素は何であるか、どんな値を入力すればいいのか？を伝えるため、ラベルの設定は必須です。
+     - この場合、FieldsetのdangerouslyTitleHidden属性をtrueにして、ラベルを非表示にしてください(https://smarthr.design/products/components/form-control/)`
 const invalidFieldsetHasRoleGroup = (fieldset, base) => `${fieldset}に 'role="group" が設定されています。${base} をつかってマークアップする場合、'role="group"' は不要です
  - ${fieldset} が ${base}、もしくはそれを拡張しているコンポーネントではない場合、名称を /(Form(Control|Group)|(F|^f)ieldset)$/ にマッチしないものに変更してください`
 const invalidChildreninFormControl = (children) => `FormControl が、${children} を子要素として持っており、マークアップとして正しくない状態になっています。以下のいずれかの方法で修正を試みてください。
@@ -79,16 +82,6 @@ const requireMultiInputInFormControlWithRoleGroup = () => `HogeFormControl内に
 ruleTester.run('a11y-input-in-form-control', rule, {
   valid: [
     { code: '<input type="hidden" />' },
-    { code: '<input title="any"/>' },
-    { code: '<HogeInput title="any"/>' },
-    { code: '<textarea title="any"/>' },
-    { code: '<HogeTextarea title="any"/>' },
-    { code: '<select title="any"/>' },
-    { code: '<HogeSelect title="any"/>' },
-    { code: '<HogeInputFile title="any"/>' },
-    { code: '<HogeComboBox title="any"/>' },
-    { code: '<HogeDatePicker title="any"/>' },
-    { code: '<HogeWarekiPicker title="any"/>' },
     { code: '<HogeFormGroup />' },
     { code: '<HogeFormControl />' },
     { code: '<HogeFieldset />' },
@@ -103,7 +96,6 @@ ruleTester.run('a11y-input-in-form-control', rule, {
     { code: '<HogeFieldset><input type="radio" /></HogeFieldset>' },
     { code: '<HogeFieldset><RadioButton /></HogeFieldset>' },
     { code: '<HogeFieldset><HogeRadioButtonPanel /></HogeFieldset>' },
-    { code: '<HogeFormControl role="group"><HogeInput /><HogeSelect /></HogeFormControl>' },
     { code: '<FugaSection><HogeFormControl><HogeInput /></HogeFormControl></FugaSection>' },
     { code: '<Stack as="section"><HogeFormControl><HogeInput /></HogeFormControl></Stack>' },
     { code: `const AnyComboBox = () => <input />` },
@@ -114,11 +106,6 @@ ruleTester.run('a11y-input-in-form-control', rule, {
     { code: '<HogeFieldset><HogeCheckBox /><HogeInput id="any" /></HogeFieldset>' },
     { code: '<FugaSection><HogeInput id="any" /></FugaSection>' },
     { code: '<HogeTextarea id="any" />' },
-    { code: '<HogeFieldset><HogeCheckBox /><HogeInput title="any" /></HogeFieldset>' },
-    { code: '<FugaSection><HogeInput title="any" /></FugaSection>' },
-    { code: '<HogeTextarea title="any" />' },
-    { code: '<HogeComboBox inputAttributes={{ title: "any" }} />' },
-    { code: '<HogeComboBox inputAttributes={{ title }} />' },
     { code: '<Fieldset><HogeRadioButtons /></Fieldset>' },
     { code: '<Fieldset><HogeRadioButtonPanels /></Fieldset>' },
     { code: '<Fieldset><HogeCheckBoxs /></Fieldset>' },
@@ -160,5 +147,21 @@ ruleTester.run('a11y-input-in-form-control', rule, {
     { code: '<HogeFormControl><HogeCheckBoxes /></HogeFormControl>', errors: [ { message: invalidMultiInputsInFormControl() } ] },
     { code: "<HogeFormControl>{ dateInput ? <DateInput /> : <Input /> }<CheckBox /></HogeFormControl>", errors: [ { message: invalidMultiInputsInFormControl() } ]},
     { code: "<HogeFormControl><CheckBox />{ dateInput ? <DateInput /> : <Input /> }</HogeFormControl>", errors: [ { message: invalidMultiInputsInFormControl() } ]},
+    { code: '<input title="any"/>', errors: [ { message: noLabeledInput('input') } ] },
+    { code: '<HogeInput title="any"/>', errors: [ { message: noLabeledInput('HogeInput') } ] },
+    { code: '<textarea title="any"/>', errors: [ { message: noLabeledInput('textarea') } ] },
+    { code: '<HogeTextarea title="any"/>', errors: [ { message: noLabeledInput('HogeTextarea') } ] },
+    { code: '<select title="any"/>', errors: [ { message: noLabeledSelect('select') } ] },
+    { code: '<HogeSelect title="any"/>', errors: [ { message: noLabeledSelect('HogeSelect') } ] },
+    { code: '<HogeInputFile title="any"/>', errors: [ { message: noLabeledInput('HogeInputFile') } ] },
+    { code: '<HogeComboBox title="any"/>', errors: [ { message: noLabeledInput('HogeComboBox') } ] },
+    { code: '<HogeDatePicker title="any"/>', errors: [ { message: noLabeledInput('HogeDatePicker') } ] },
+    { code: '<HogeWarekiPicker title="any"/>', errors: [ { message: noLabeledInput('HogeWarekiPicker') } ] },
+    { code: '<HogeFieldset><HogeCheckBox /><HogeInput title="any" /></HogeFieldset>', errors: [ { message: noLabeledInputInFieldset('HogeInput') } ] },
+    { code: '<FugaSection><HogeInput title="any" /></FugaSection>', errors: [ { message: useFormControlInsteadOfSection('HogeInput', 'FugaSection') } ] },
+    { code: '<HogeTextarea title="any" />', errors: [ { message: noLabeledInput('HogeTextarea') } ] },
+    { code: '<HogeComboBox inputAttributes={{ title: "any" }} />', errors: [ { message: noLabeledInput('HogeComboBox') } ] },
+    { code: '<HogeComboBox inputAttributes={{ title }} />', errors: [ { message: noLabeledInput('HogeComboBox') } ] },
+    { code: '<HogeFormControl role="group"><HogeInput /><HogeSelect /></HogeFormControl>', errors: [ { message: invalidMultiInputsInFormControl() } ] },
   ]
 })


### PR DESCRIPTION
- 現在の入力要素にラベルの設定を促すチェックを修正したい
- 不可視のラベルを設定したい場合、title属性の設定を促していますがこれをやめて必ず FormControl もしくは Fieldset でラップしてもらうようにしたいと考えている
  - 現時点のtitleでも問題なくラベルは設定されているが実はこの方法はラベル設定の際、ブラウザが行っているチェック順序の最下位、failsafe的なもの
- この修正が行われた場合、不可視のラベルはdangerouslyTitleHidden属性をtrueにしてもらうことで対応してもらうようになります
- titleやaria-labelなどでa11y nameを設定していても、この修正後はエラーになります