### PR TITLE
fix: i18n パッケージを ts のビルド対象に含める

### DIFF
--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "./use-virtual-scroll" },
     { "path": "./wareki" },
     { "path": "./create-lint-set" },
-    { "path": "./next-auth" }
+    { "path": "./next-auth" },
+    { "path": "./i18n" }
   ]
 }


### PR DESCRIPTION
## 経緯

リリースした i18n パッケージに lib ディレクトリが含まれておらず、プロダクト側から import ができていなかった。
lib ディレクトリが含まれるようにしたい。

## やったこと

`packages/tsconfg.json` で i18n を参照対象に追加。