### PR TITLE
chore: trusted publishing 対応

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,16 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     needs: release_please
     if: ${{ needs.release_please.outputs.releases_created == 'true' }}
     steps:
       - uses: actions/checkout@v5
-      - run: npm install -g corepack@latest
+      - run: |
+          npm install -g npm@latest
+          echo "Updated npm version: $(npm -v)"
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -34,5 +39,3 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install
       - run: pnpm release --no-push --no-private --yes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.KUFU_NPM_RELEASE_TOKEN }}


### PR DESCRIPTION
## やりたいこと

Trusted Publishing でパッケージを公開するようにしたい

## やったこと

https://docs.npmjs.com/trusted-publishers#configuring-trusted-publishing の手順に従って作業を行いました

① npm 側の各パッケージで Trusted Publisher の設定を追加

<img width="816" height="602" alt="image" src="https://github.com/user-attachments/assets/7df75ee2-1622-4a17-add0-5926489e4080" />

② ついでに2要素認証の設定が各パッケージによってまちまちだったのですべて必須に変更 (Trusted Publishering の場合はどれを選んでても良い)
<img width="795" height="352" alt="image" src="https://github.com/user-attachments/assets/cba804aa-c8a8-40ce-93b3-c9730f51cefb" />

③ github actions の workflow を修正 (このプルリク)