### PR TITLE
chore: pnpm/action-setup を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.14.0
+          package_json_file: 'package.json'
           run_install: false
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
master の github action が落ちている (https://github.com/kufu/tamatebako/actions/runs/18153278952) のでその対応です。
内容は

> Unable to locate executable file: pnpm. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.

なので、pnpm コマンドが使えるようになるように pnpm/action-setup を追加しています。

今まで pnpm が動いてた理由が謎なのですが、今日 https://github.com/kufu/tamatebako/pull/756 で node のバージョンが上がっていることから、今まではキャッシュを使いまわせていたということなのか......？とか思っています (最初の pnpm のキャッシュがどうやってできたのかはわからないですが......)