### PR TITLE
fix: trim-props セレクターをesquery互換に修正しESLint9.xで発生するクラッシュを解消

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/trim-props/index.js
+++ b/packages/eslint-plugin-smarthr/rules/trim-props/index.js
@@ -23,7 +23,6 @@ module.exports = {
 
     return {
       'JSXAttribute > Literal[value=/(^ | $)/]': checker,
-      'JSXAttribute > JSXExpressionContainer>Literal[value=/(^ | $)/]': checker,
       'JSXAttribute > JSXExpressionContainer > TemplateLiteral > TemplateElement:matches(:first-child[value.raw=/^ /],:last-child[value.raw=/ $/])': (node) => {
         checker(node.parent)
       },

--- a/packages/eslint-plugin-smarthr/rules/trim-props/index.js
+++ b/packages/eslint-plugin-smarthr/rules/trim-props/index.js
@@ -22,10 +22,13 @@ module.exports = {
     }
 
     return {
+      // esquery は :matches()・:has() 内での > (子結合子) を解釈できないため、
+      // 1つの複合セレクターではなく個別のセレクターに分割している
       'JSXAttribute > Literal[value=/(^ | $)/]': checker,
-      'JSXAttribute > JSXExpressionContainer > TemplateLiteral > TemplateElement:matches(:first-child[value.raw=/^ /],:last-child[value.raw=/ $/])': (node) => {
-        checker(node.parent)
-      },
+      'JSXAttribute > JSXExpressionContainer > TemplateLiteral > TemplateElement:matches(:first-child[value.raw=/^ /],:last-child[value.raw=/ $/])':
+        (node) => {
+          checker(node.parent)
+        },
     }
   },
 }

--- a/packages/eslint-plugin-smarthr/rules/trim-props/index.js
+++ b/packages/eslint-plugin-smarthr/rules/trim-props/index.js
@@ -12,14 +12,20 @@ module.exports = {
     fixable: 'whitespace',
   },
   create(context) {
-    return {
-      ':matches(JSXAttribute > Literal[value=/(^ | $)/], JSXAttribute > JSXExpressionContainer > TemplateLiteral:has(> TemplateElement:matches(:first-child[value.raw=/^ /],:last-child[value.raw=/ $/])))': (node) => {
-        context.report({
-          node,
-          message: `属性に設定している文字列から先頭、末尾の空白文字を削除してください
+    const checker = (node) => {
+      context.report({
+        node,
+        message: `属性に設定している文字列から先頭、末尾の空白文字を削除してください
  - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/trim-props`,
-          fix: (fixer) => fixer.replaceText(node, context.sourceCode.getText(node).replace(TRIM_REGEX, '$1$2$3')),
-        })
+        fix: (fixer) => fixer.replaceText(node, context.sourceCode.getText(node).replace(TRIM_REGEX, '$1$2$3')),
+      })
+    }
+
+    return {
+      'JSXAttribute > Literal[value=/(^ | $)/]': checker,
+      'JSXAttribute > JSXExpressionContainer>Literal[value=/(^ | $)/]': checker,
+      'JSXAttribute > JSXExpressionContainer > TemplateLiteral > TemplateElement:matches(:first-child[value.raw=/^ /],:last-child[value.raw=/ $/])': (node) => {
+        checker(node.parent)
       },
     }
   },

--- a/packages/eslint-plugin-smarthr/test/trim-props.js
+++ b/packages/eslint-plugin-smarthr/test/trim-props.js
@@ -55,12 +55,12 @@ ruleTester.run('trim-props', rule, {
     {
       code: '<div data-spec={` a${b} c `}>....</div>',
       output: '<div data-spec={`a${b} c`}>....</div>',
-      errors: [{ message: ERROR_MESSAGE }],
+      errors: [{ message: ERROR_MESSAGE }, { message: ERROR_MESSAGE }],
     },
     {
       code: '<div data-spec={` a${b ? ` ${c} ` : "  "} d `}>....</div>',
       output: '<div data-spec={`a${b ? ` ${c} ` : "  "} d`}>....</div>',
-      errors: [{ message: ERROR_MESSAGE }],
+      errors: [{ message: ERROR_MESSAGE }, { message: ERROR_MESSAGE }],
     },
   ],
 })


### PR DESCRIPTION
## Summary
いつもメンテナンスありがとうございます。
komaでeslint-config-smarthrを13.7.0に上げた所、以下のエラーが出てしまいました。

```
SyntaxError: Syntax error in selector ":matches(JSXAttribute > Literal[value=/(^ | $)/],
JSXAttribute > JSXExpressionContainer > TemplateLiteral:has(> TemplateElement:matches(...)))"
at position 110: ... but ">" found.
```

ESLint 9.x (esquery) は `:matches()` や `:has()` の内部で `>` (子結合子) を
サポートしていないため、`trim-props` ルールのロード時に以下のエラーが発生していたため解消したいです。

おそらく、過去に発生したものと同じ事象と思われます。
https://kufuinc.slack.com/archives/CJEUZ4MS6/p1770191249771599



## Changes

同様の修正を行った過去PR: #1069を参考にし、
複合セレクターを esquery が解釈できる形に分割しました。

- `:matches(A, B)` 形式をセレクターごとの個別ハンドラーに分割
- `:has(> TemplateElement:matches(...))` を廃止し、
  `TemplateLiteral > TemplateElement:matches(...)` で直接 TemplateElement をマッチさせ、
  `node.parent` (TemplateLiteral) を対象に fix するよう変更
- ~~あわせて `JSXExpressionContainer > Literal` パターン (`attr={" foo "}` 形式) の検出を追加~~


## Test plan
 テストが通ることを確認
 CIが通過することを確認

