### PR TITLE
fix(require-barrel-import): commonParentのbarrelを除外して同一ツリー内の相対importを許可

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/require-barrel-import/index.js
+++ b/packages/eslint-plugin-smarthr/rules/require-barrel-import/index.js
@@ -105,6 +105,24 @@ const isImportedInsideImporter = (importerDir, importedPath) => {
 }
 
 /**
+ * 2つのパスの共通の親ディレクトリを見つける
+ * @param {string} path1 - パス1
+ * @param {string} path2 - パス2
+ * @returns {string} 共通の親ディレクトリの絶対パス
+ */
+const findCommonParent = (path1, path2) => {
+  const segments1 = path1.split('/')
+  const segments2 = path2.split('/')
+
+  let i = 0
+  while (i < segments1.length && i < segments2.length && segments1[i] === segments2[i]) {
+    i++
+  }
+
+  return segments1.slice(0, i).join('/')
+}
+
+/**
  * allowedImportsオプションに基づいて、特定のimportが許可されているかチェックする
  * @param {object} node - ImportDeclaration node
  * @param {string} importerDir - import元のディレクトリ
@@ -167,6 +185,10 @@ const findBarrelFile = (importedPath, importerDir) => {
   let currentPath = importedPath
   let barrel = undefined
 
+  // import元とimport先の共通の親ディレクトリを見つける
+  // 共通の親のbarrelファイルは除外する（同じディレクトリツリー内の相対importには適用されない）
+  const commonParent = findCommonParent(importerDir, importedPath)
+
   // ディレクトリ指定の場合、そのindex.tsを指していることは自明なので一階層上から探索
   if (fs.existsSync(currentPath) && fs.statSync(currentPath).isDirectory()) {
     pathSegments.pop()
@@ -175,9 +197,10 @@ const findBarrelFile = (importedPath, importerDir) => {
 
   while (pathSegments.length > 0) {
     // 以下の場合は探索終了
-    // 1. いずれかのreplacePathsのルートに到達した場合
-    // 2. import先がimport元の内部にある場合（同階層・サブディレクトリからのimport）
-    if (ALL_ROOT_PATHS.includes(currentPath) || isImportedInsideImporter(importerDir, currentPath)) {
+    // 1. 共通の親ディレクトリに到達した場合（commonParent自体のbarrelは除外）
+    // 2. いずれかのreplacePathsのルートに到達した場合
+    // 3. import先がimport元の内部にある場合（同階層・サブディレクトリからのimport）
+    if (currentPath === commonParent || ALL_ROOT_PATHS.includes(currentPath) || isImportedInsideImporter(importerDir, currentPath)) {
       break
     }
 

--- a/packages/eslint-plugin-smarthr/test/require-barrel-import.js
+++ b/packages/eslint-plugin-smarthr/test/require-barrel-import.js
@@ -261,21 +261,69 @@ ruleTester.run('require-barrel-import', rule, {
         return `${fixturesRoot}/path-alias-parent-no-barrel/Button/Button.tsx`
       })(),
     },
-  ],
 
-  invalid: [
-    // 親階層からのimport（barrelが存在する場合）
+    // 親階層からのimport（commonParentにbarrelがある場合）
     {
       code: `import { createUserRole } from '../hooks/createUserRoleAction'`,
       filename: (() => {
-        createFixture('parent-import-with-barrel', {
+        createFixture('parent-import-common-parent-barrel', {
           'components': {
-            'index.tsx': 'export {}',
+            'index.tsx': 'export {}',  // commonParentのbarrelは除外される
             'AddDialog': {
               'AddDialog.tsx': '',
             },
             'hooks': {
               'createUserRoleAction.ts': '',
+            },
+          },
+        })
+        return `${fixturesRoot}/parent-import-common-parent-barrel/components/AddDialog/AddDialog.tsx`
+      })(),
+    },
+
+    // 複雑なネスト - commonParentのbarrelは除外される
+    {
+      code: `import type { RequestStepActionNotSkipped } from '../utils/withSkipped'`,
+      filename: (() => {
+        createFixture('nested-common-parent-barrel', {
+          'Nodes': {
+            'index.tsx': 'export {}',  // commonParentより上のbarrel（除外される）
+            'StepNodeRequestView': {
+              'index.tsx': 'export {}',  // commonParent（除外される）
+              'Approvers': {
+                'ApproverRow': {
+                  'buildUserRowsProps.ts': '',
+                },
+                'utils': {
+                  'withSkipped': {
+                    'index.ts': 'export {}',  // import先のbarrel（valid）
+                  },
+                },
+              },
+            },
+          },
+        })
+        return `${fixturesRoot}/nested-common-parent-barrel/Nodes/StepNodeRequestView/Approvers/ApproverRow/buildUserRowsProps.ts`
+      })(),
+      languageOptions: {
+        parser: require('typescript-eslint').parser,
+      },
+    },
+  ],
+
+  invalid: [
+    // 親階層からのimport（import先の親にbarrelがある場合）
+    {
+      code: `import { api } from '../api/client'`,
+      filename: (() => {
+        createFixture('parent-import-with-barrel', {
+          'components': {
+            'AddDialog': {
+              'AddDialog.tsx': '',
+            },
+            'api': {
+              'index.tsx': 'export {}',  // import先の親にbarrel
+              'client.ts': '',
             },
           },
         })
@@ -288,106 +336,22 @@ ruleTester.run('require-barrel-import', rule, {
       ],
     },
 
-    // Next.js特殊文字パス - 親階層からのimport
-    {
-      code: `import { createUserRole } from '../hooks/createUserRoleAction'`,
-      filename: (() => {
-        createFixture('nextjs-parent-import', {
-          'app': {
-            '(private)': {
-              'settings': {
-                'user_roles': {
-                  '_components': {
-                    'index.tsx': 'export {}',
-                    'AddUserRoleDialog': {
-                      'AddUserRoleDialog.tsx': '',
-                    },
-                    'hooks': {
-                      'createUserRoleAction.ts': '',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        })
-        return `${fixturesRoot}/nextjs-parent-import/app/(private)/settings/user_roles/_components/AddUserRoleDialog/AddUserRoleDialog.tsx`
-      })(),
-      errors: [
-        {
-          message: /からimportするか、.*のbarrelファイルを削除して直接import可能にしてください/,
-        },
-      ],
-    },
-
-    // [id] Dynamic Routes - 親階層からのimport
+    // Next.js特殊文字パス - import先の親にbarrel
     {
       code: `import { api } from '../api/client'`,
       filename: (() => {
-        createFixture('dynamic-route-parent-import', {
-          'app': {
-            'items': {
-              'index.tsx': 'export {}',
-              '[id]': {
-                'DetailPage.tsx': '',
-              },
-              'api': {
-                'client.ts': '',
-              },
-            },
-          },
-        })
-        return `${fixturesRoot}/dynamic-route-parent-import/app/items/[id]/DetailPage.tsx`
-      })(),
-      errors: [
-        {
-          message: /からimportするか、.*のbarrelファイルを削除して直接import可能にしてください/,
-        },
-      ],
-    },
-
-    // ============================================================
-    // Path alias - 親階層からのimport（barrelあり）
-    // ============================================================
-    {
-      code: `import { createUserRole } from '~/path-alias-parent-import-with-barrel/components/hooks/createUserRoleAction'`,
-      filename: (() => {
-        createFixture('path-alias-parent-import-with-barrel', {
-          'components': {
-            'index.tsx': 'export {}',
-            'AddDialog': {
-              'AddDialog.tsx': '',
-            },
-            'hooks': {
-              'createUserRoleAction.ts': '',
-            },
-          },
-        })
-        return `${fixturesRoot}/path-alias-parent-import-with-barrel/components/AddDialog/AddDialog.tsx`
-      })(),
-      errors: [
-        {
-          message: /からimportするか、.*のbarrelファイルを削除して直接import可能にしてください/,
-        },
-      ],
-    },
-
-    // Path alias + Next.js特殊文字パス - 親階層からのimport
-    {
-      code: `import { createUserRole } from '~/path-alias-nextjs-parent/app/(private)/settings/user_roles/_components/hooks/createUserRoleAction'`,
-      filename: (() => {
-        createFixture('path-alias-nextjs-parent', {
+        createFixture('nextjs-import-parent-barrel', {
           'app': {
             '(private)': {
               'settings': {
                 'user_roles': {
                   '_components': {
-                    'index.tsx': 'export {}',
                     'AddUserRoleDialog': {
                       'AddUserRoleDialog.tsx': '',
                     },
-                    'hooks': {
-                      'createUserRoleAction.ts': '',
+                    'api': {
+                      'index.tsx': 'export {}',  // import先の親にbarrel
+                      'client.ts': '',
                     },
                   },
                 },
@@ -395,7 +359,31 @@ ruleTester.run('require-barrel-import', rule, {
             },
           },
         })
-        return `${fixturesRoot}/path-alias-nextjs-parent/app/(private)/settings/user_roles/_components/AddUserRoleDialog/AddUserRoleDialog.tsx`
+        return `${fixturesRoot}/nextjs-import-parent-barrel/app/(private)/settings/user_roles/_components/AddUserRoleDialog/AddUserRoleDialog.tsx`
+      })(),
+      errors: [
+        {
+          message: /からimportするか、.*のbarrelファイルを削除して直接import可能にしてください/,
+        },
+      ],
+    },
+
+    // Path alias - import先の親にbarrel
+    {
+      code: `import { api } from '~/path-alias-import-parent-barrel/components/api/client'`,
+      filename: (() => {
+        createFixture('path-alias-import-parent-barrel', {
+          'components': {
+            'AddDialog': {
+              'AddDialog.tsx': '',
+            },
+            'api': {
+              'index.tsx': 'export {}',  // import先の親にbarrel
+              'client.ts': '',
+            },
+          },
+        })
+        return `${fixturesRoot}/path-alias-import-parent-barrel/components/AddDialog/AddDialog.tsx`
       })(),
       errors: [
         {


### PR DESCRIPTION
## Summary
同じディレクトリツリー内の相対importで、共通の親ディレクトリのbarrelファイルが誤検知される問題を修正。

## 問題
以下のような構造で、`buildUserRowsProps.ts`から`withSkipped`をimportする際に、`Nodes/index.tsx`を使うよう誤って要求していた：

```
/Nodes/
├── index.tsx
└── StepNodeRequestView/
    ├── index.tsx
    ├── Approvers/ApproverRow/buildUserRowsProps.ts
    └── utils/withSkipped/index.ts
```

## 修正内容
- `findCommonParent`関数を追加：import元とimport先の共通の親ディレクトリを計算
- `findBarrelFile`関数を修正：commonParentに到達したら探索を終了
- これにより、共通の親より上のbarrelは検出されなくなる

## 変更ファイル
- `rules/require-barrel-import/index.js`: ロジック修正
- `test/require-barrel-import.js`: テストケース追加・整理

## Test plan
- [x] `pnpm test` 実行済み（1146 tests passed）
- [x] 新しいテストケース追加：複雑なネスト構造でcommonParentが除外されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)