### PR TITLE
fix(eslint-config): eslint-plugin-smarthr 6.10.3に更新

### DIFF
--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-smarthr": "6.10.2",
+    "eslint-plugin-smarthr": "6.10.3",
     "globals": "^17.4.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.10.2
-        version: 6.10.2(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.10.3
+        version: 6.10.3(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.4.0
         version: 17.4.0
@@ -3864,8 +3864,8 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-smarthr@6.10.2:
-    resolution: {integrity: sha512-Mbp/Ze+YxivkizmrCJwyLHdUHWCdK4K5lcZ0x3LtRl2EXfKzToDE8LqPvgwL6Sp6Nk2VJLMxzIKDZGD1BKcU9w==}
+  eslint-plugin-smarthr@6.10.3:
+    resolution: {integrity: sha512-DB2jwrkUy7FRBoLmu3fP1aqpDmKA/cnI6m61ayru5CfYB1CDrugXy9CoE8zQDQCVIEnvaRRTIL7muSFJGH435w==}
     engines: {node: '>=24.14.1'}
     peerDependencies:
       eslint: ^9
@@ -11639,7 +11639,7 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-smarthr@6.10.2(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-smarthr@6.10.3(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary
- eslint-plugin-smarthr を 6.10.2 → 6.10.3 に更新
- 重要なバグ修正を含むバージョンに更新

## 主な修正内容
- require-barrel-import: commonParentのbarrelを除外して同一ツリー内の相対importを許可
- trim-props: ESLint 9.xでのクラッシュを解消

## Changes
- package.json: eslint-plugin-smarthr 6.10.3に更新
- pnpm-lock.yaml: 依存関係を更新

## Test plan
- [x] `pnpm test` 実行済み（成功）

🤖 Generated with [Claude Code](https://claude.com/claude-code)