### PR TITLE
feat(require-barrel-import): エラーメッセージを詳細化して実用性を向上

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/require-barrel-import/index.js
+++ b/packages/eslint-plugin-smarthr/rules/require-barrel-import/index.js
@@ -296,13 +296,36 @@ module.exports = {
         const barrelDirWithAlias = barrelWithAlias.replace(REGEX_INDEX_FILE, '')
         const uniqueDeniedModules = [...new Set(deniedModules.flat())]
 
+        // importしているモジュール名を取得
+        const importedModules = node.specifiers
+          .map(s => s.imported?.name || s.local?.name)
+          .filter(Boolean)
+          .join(', ')
+
+        // 推奨されるimportパスを生成（元の記法に合わせる）
+        let suggestedImportPath = barrelDirWithAlias
+        if (node.source.value[0] === '.') {
+          // 相対パスの場合、barrelDirへの相対パスを計算
+          const barrelDirAbsolute = resolvePathAlias(barrelDirWithAlias)
+          const relativePath = path.relative(importerDir, barrelDirAbsolute)
+          suggestedImportPath = relativePath.startsWith('.') ? relativePath : `./${relativePath}`
+        }
+
         // エラーを報告
         context.report({
           node,
           message: uniqueDeniedModules.length
             ? `${uniqueDeniedModules.join(', ')} は ${barrelDirWithAlias} からimportしてください`
-            : `${barrelDirWithAlias} からimportするか、${barrelWithAlias} のbarrelファイルを削除して直接import可能にしてください`
-              + '\n - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/require-barrel-import',
+            : `バレルファイルを経由してimportしてください
+
+検出されたバレル: ${barrelWithAlias}
+現在のimport:      import { ${importedModules} } from '${node.source.value}'
+推奨されるimport:  import { ${importedModules} } from '${suggestedImportPath}'
+
+注意: バレルファイルに ${importedModules} のexportが必要です。
+      存在しない場合は ${path.basename(barrelPath)} に追加してください。
+
+詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/require-barrel-import`,
         })
       },
     }

--- a/packages/eslint-plugin-smarthr/test/require-barrel-import.js
+++ b/packages/eslint-plugin-smarthr/test/require-barrel-import.js
@@ -331,7 +331,7 @@ ruleTester.run('require-barrel-import', rule, {
       })(),
       errors: [
         {
-          message: /からimportするか、.*のbarrelファイルを削除して直接import可能にしてください/,
+          message: /バレルファイルを経由してimportしてください/,
         },
       ],
     },
@@ -363,7 +363,7 @@ ruleTester.run('require-barrel-import', rule, {
       })(),
       errors: [
         {
-          message: /からimportするか、.*のbarrelファイルを削除して直接import可能にしてください/,
+          message: /バレルファイルを経由してimportしてください/,
         },
       ],
     },
@@ -387,7 +387,7 @@ ruleTester.run('require-barrel-import', rule, {
       })(),
       errors: [
         {
-          message: /からimportするか、.*のbarrelファイルを削除して直接import可能にしてください/,
+          message: /バレルファイルを経由してimportしてください/,
         },
       ],
     },


### PR DESCRIPTION
## Summary
プロダクトでの使用時により分かりやすいエラーメッセージに改善。

## Before
```
@/components からimportするか、@/components/index.tsx のbarrelファイルを削除して直接import可能にしてください
 - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/require-barrel-import
```

## After

### 相対パスの場合
```
バレルファイルを経由してimportしてください

検出されたバレル: ~/components/api/index.tsx
現在のimport:      import { api } from '../api/client'
推奨されるimport:  import { api } from '../api'

注意: バレルファイルに api のexportが必要です。
      存在しない場合は index.tsx に追加してください。

詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/require-barrel-import
```

### path aliasの場合
```
バレルファイルを経由してimportしてください

検出されたバレル: @/components/api/index.tsx
現在のimport:      import { api } from '@/components/api/client'
推奨されるimport:  import { api } from '@/components/api'

注意: バレルファイルに api のexportが必要です。
      存在しない場合は index.tsx に追加してください。

詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/require-barrel-import
```

## 主な追加情報
1. **現在のimport文を明示** - どこから何をimportしているか一目瞭然
2. **推奨されるimport文を具体的に表示** - 元の記法に合わせて相対パス/path aliasを使い分け
3. **バレルファイルにexportが必要な旨を注意書き** - 実装時の手順が明確に

## 技術的詳細
- 相対パスの場合: `importerDir`から`barrelDir`への相対パスを計算
- path aliasの場合: そのままpath aliasを使用
- **検出ロジックは変更なし**（エラーメッセージのみ改善）

## Test plan
- [x] `pnpm test` 実行済み（1146 tests passed）
- [x] テストケースのmessage正規表現を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)