### PR TITLE
fix(eslint-config-smarthr): eslint-plugin-smarthr 6.10.4に更新

### DIFF
--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-smarthr": "6.10.3",
+    "eslint-plugin-smarthr": "6.10.4",
     "globals": "^17.4.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.10.3
-        version: 6.10.3(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.10.4
+        version: 6.10.4(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.4.0
         version: 17.4.0
@@ -3864,8 +3864,8 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-smarthr@6.10.3:
-    resolution: {integrity: sha512-DB2jwrkUy7FRBoLmu3fP1aqpDmKA/cnI6m61ayru5CfYB1CDrugXy9CoE8zQDQCVIEnvaRRTIL7muSFJGH435w==}
+  eslint-plugin-smarthr@6.10.4:
+    resolution: {integrity: sha512-ONcDxp+r3zk7tkgaGlcBkcTKg5DqZ+J++rdn1pfM25BUrLYTr7Z/xxIc6LEUYhoPU3MOdDuIE/tB7rOEFeC0FQ==}
     engines: {node: '>=24.14.1'}
     peerDependencies:
       eslint: ^9
@@ -11639,7 +11639,7 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-smarthr@6.10.3(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-smarthr@6.10.4(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary
- eslint-config-smarthr の依存する eslint-plugin-smarthr のバージョンを 6.10.3 → 6.10.4 に更新

取り込みたいルールのPR
- https://github.com/kufu/tamatebako/pull/1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)