### PR TITLE
fix(eslint-plugin-smarthr): 不要な engines フィールドを削除

### DIFF
--- a/packages/eslint-plugin-smarthr/package.json
+++ b/packages/eslint-plugin-smarthr/package.json
@@ -5,9 +5,6 @@
   "license": "MIT",
   "description": "A sharable ESLint plugin for SmartHR",
   "main": "index.js",
-  "engines": {
-    "node": ">=24.14.1"
-  },
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
## Summary

- `eslint-plugin-smarthr` の `package.json` から `engines` フィールド (`"node": ">=24.14.1"`) を削除
- このパッケージは Node 24 に依存しているわけではなく、不必要な制約により使用している Node バージョンによってインストールが困難になっていたため

🤖 Generated with [Claude Code](https://claude.com/claude-code)