### PR TITLE
fix(format-import-path): .presentational等の拡張子が誤って削除される問題を修正

### DIFF
--- a/packages/eslint-plugin-smarthr/libs/common_domain.js
+++ b/packages/eslint-plugin-smarthr/libs/common_domain.js
@@ -63,7 +63,7 @@ const calculateDomainNode = (calclatedContext, node) => {
       replacedPath = exts.map((j) => `${replacedPath}${j}`).find((j) => fs.existsSync(j)) || replacedPath
     }
 
-    replacedPath = replacedPath.replace(/^(.+?)((\/index)?\.[a-z0-9]+|\/)$/, '$1')
+    replacedPath = replacedPath.replace(/^(.+?)((\/index)?\.(js|jsx|ts|tsx)|\/)$/, '$1')
   }
 
   const resolvedImportPath = replacedPath[0] === '/' ? replacedPath : ''

--- a/packages/eslint-plugin-smarthr/test/format-import-path.js
+++ b/packages/eslint-plugin-smarthr/test/format-import-path.js
@@ -1,0 +1,126 @@
+const rule = require('../rules/format-import-path')
+const RuleTester = require('eslint').RuleTester
+const path = require('path')
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2015,
+      sourceType: 'module',
+    },
+  },
+})
+
+const DOMAIN_RULE_ARGS = {
+  globalModuleDir: ['./src/modules'],
+  domainModuleDir: ['modules'],
+  domainConstituteDir: ['components', 'hooks', 'utils'],
+  format: { all: 'relative' },
+}
+
+// テスト用のファイルパスを作成
+const createFilePath = (relativePath) => {
+  return path.resolve(__dirname, '../src', relativePath)
+}
+
+ruleTester.run('format-import-path', rule, {
+  valid: [
+    // ============================================================
+    // 拡張子除去のテスト
+    // ============================================================
+
+    // .presentational などのファイル名の一部は保持される
+    {
+      code: `import { Header } from './Header.presentational'`,
+      filename: createFilePath('components/Page.tsx'),
+      options: [DOMAIN_RULE_ARGS],
+    },
+
+    // .container も保持される
+    {
+      code: `import { List } from './List.container'`,
+      filename: createFilePath('components/Page.tsx'),
+      options: [DOMAIN_RULE_ARGS],
+    },
+
+    // .stories も保持される
+    {
+      code: `import { meta } from './Button.stories'`,
+      filename: createFilePath('components/Page.tsx'),
+      options: [DOMAIN_RULE_ARGS],
+    },
+  ],
+
+  invalid: [
+    // ============================================================
+    // 拡張子除去のテスト（JS/TS拡張子のみ除去）
+    // ============================================================
+
+    // .tsx は除去される
+    {
+      code: `import { Header } from './Header.tsx'`,
+      output: `import { Header } from './Header'`,
+      filename: createFilePath('components/Page.tsx'),
+      options: [DOMAIN_RULE_ARGS],
+      errors: [{ message: /に修正してください/ }],
+    },
+
+    // .ts は除去される
+    {
+      code: `import { utils } from './utils.ts'`,
+      output: `import { utils } from './utils'`,
+      filename: createFilePath('components/Page.tsx'),
+      options: [DOMAIN_RULE_ARGS],
+      errors: [{ message: /に修正してください/ }],
+    },
+
+    // .jsx は除去される
+    {
+      code: `import { Button } from './Button.jsx'`,
+      output: `import { Button } from './Button'`,
+      filename: createFilePath('components/Page.tsx'),
+      options: [DOMAIN_RULE_ARGS],
+      errors: [{ message: /に修正してください/ }],
+    },
+
+    // .js は除去される
+    {
+      code: `import { helper } from './helper.js'`,
+      output: `import { helper } from './helper'`,
+      filename: createFilePath('components/Page.tsx'),
+      options: [DOMAIN_RULE_ARGS],
+      errors: [{ message: /に修正してください/ }],
+    },
+
+    // ============================================================
+    // 複数拡張子のテスト（.presentational.tsx など）
+    // ============================================================
+
+    // .presentational.tsx → .presentational (.tsxのみ除去)
+    {
+      code: `import { Header } from './Header.presentational.tsx'`,
+      output: `import { Header } from './Header.presentational'`,
+      filename: createFilePath('components/Page.tsx'),
+      options: [DOMAIN_RULE_ARGS],
+      errors: [{ message: /に修正してください/ }],
+    },
+
+    // .container.ts → .container (.tsのみ除去)
+    {
+      code: `import { List } from './List.container.ts'`,
+      output: `import { List } from './List.container'`,
+      filename: createFilePath('components/Page.tsx'),
+      options: [DOMAIN_RULE_ARGS],
+      errors: [{ message: /に修正してください/ }],
+    },
+
+    // .stories.tsx → .stories (.tsxのみ除去)
+    {
+      code: `import { meta } from './Button.stories.tsx'`,
+      output: `import { meta } from './Button.stories'`,
+      filename: createFilePath('components/Page.tsx'),
+      options: [DOMAIN_RULE_ARGS],
+      errors: [{ message: /に修正してください/ }],
+    },
+  ],
+})


### PR DESCRIPTION
## Summary
- format-import-pathルールで `.presentational`、`.container`、`.stories` などの意味のある拡張子が誤って削除される問題を修正
- test/format-import-path.js を新規作成し、テストカバレッジを追加

## 問題
format-import-pathルールで、`.presentational`、`.container`、`.stories` などの意味のある拡張子が誤って削除されていた。

**例:**
```typescript
// Before (誤り)
import { Header } from './Header.presentational'
// ↓ format-import-pathが適用されると
import { Header } from './Header'  // .presentationalが削除されてしまう

// After (正しい)
import { Header } from './Header.presentational'  // .presentationalは保持される
```

## 原因
`libs/common_domain.js:66` の拡張子削除ロジックで、全ての拡張子を削除する正規表現 `/\.[a-z0-9]+$/` を使用していたため。

## 修正内容
1. **拡張子削除ロジックの修正**
   - 正規表現を `/\.(js|jsx|ts|tsx)$/` に変更し、JS/TS拡張子のみ削除するように修正
   - `.presentational`、`.container`、`.stories` などは保持される

2. **テストカバレッジの追加**
   - `test/format-import-path.js` を新規作成
   - `.presentational` 等の保持を確認
   - `.tsx`/`.ts`/`.jsx`/`.js` 拡張子の削除を確認
   - 複数拡張子（`.presentational.tsx` → `.presentational`）の処理を確認

## Test plan
- [x] `pnpm test test/format-import-path.js` が通ることを確認
- [x] `pnpm test` で全テストが通ることを確認
- [x] 実際のプロダクトで動作確認（必要に応じて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)