### PR TITLE
chore(eslint-config-smarthr): update eslint-plugin-smarthr to 6.11.0

### DIFF
--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-smarthr": "6.10.4",
+    "eslint-plugin-smarthr": "6.11.0",
     "globals": "^17.4.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.10.4
-        version: 6.10.4(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.11.0
+        version: 6.11.0(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.4.0
         version: 17.4.0
@@ -3998,6 +3998,11 @@ packages:
   eslint-plugin-smarthr@6.10.4:
     resolution: {integrity: sha512-ONcDxp+r3zk7tkgaGlcBkcTKg5DqZ+J++rdn1pfM25BUrLYTr7Z/xxIc6LEUYhoPU3MOdDuIE/tB7rOEFeC0FQ==}
     engines: {node: '>=24.14.1'}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.11.0:
+    resolution: {integrity: sha512-YjHFCiWCKwGomc2luTB5vn7o2TtbVoIzHGcKtuNuCY2wEKhx8v+Th8QU6LNRF1KQeEldoppv6X3l8bkAffx4nw==}
     peerDependencies:
       eslint: ^9
 
@@ -11841,6 +11846,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.10.4(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.11.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary
- `eslint-config-smarthr` の dependency である `eslint-plugin-smarthr` を `6.10.4` → `6.11.0` に更新

## Test plan
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)