### PR TITLE
fix(format-import-path): dirCount関数でmatch結果がnullの場合のエラーを修正

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/format-import-path/index.js
+++ b/packages/eslint-plugin-smarthr/rules/format-import-path/index.js
@@ -28,7 +28,11 @@ const DIR_SEPARATE_REGEX = /\//g
 const MULTIPLE_DIR_SEPARATE_REGEX =/(\/)+/g
 const TRAILING_SLASH_REGEX = /^(.+?)\/$/
 
-const dirCount = (dir) => dir.match(DIR_SEPARATE_REGEX).length
+const dirCount = (dir) => {
+  if (!dir) return 0
+  const matches = dir.match(DIR_SEPARATE_REGEX)
+  return matches ? matches.length : 0
+}
 
 const convertType = (calcContext, calcDomainNode) => {
   const { option: { format: { all, outside, globalModule, module, domain, lower } } } = calcContext


### PR DESCRIPTION
## 概要

`format-import-path` ルールの `dirCount` 関数で、`'/'` を含まない文字列を受け取った場合にエラーが発生するバグを修正しました。

## バグの詳細

**発生条件:**
`'abc'` のように `'/'` を含まない文字列を `dirCount` 関数に渡した場合

**エラー原因:**
```javascript
const dirCount = (dir) => dir.match(DIR_SEPARATE_REGEX).length
```

- `dir.match(DIR_SEPARATE_REGEX)` は、マッチするものがない場合に `null` を返す
- `null.length` にアクセスしようとしてエラーが発生

## 修正内容

```javascript
const dirCount = (dir) => {
  if (!dir) return 0
  const matches = dir.match(DIR_SEPARATE_REGEX)
  return matches ? matches.length : 0
}
```

- `match()` の結果が `null` の場合は `0` を返すように変更
- `dir` が空文字列や `null`/`undefined` の場合も `0` を返すように対応

## テスト結果

全19テストが通過しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)