### PR TITLE
chore: release master

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/create-lint-set": "1.1.5",
-  "packages/eslint-config-smarthr": "13.12.0",
+  "packages/eslint-config-smarthr": "13.12.1",
   "packages/eslint-plugin-smarthr": "6.11.0",
   "packages/next-auth": "0.1.6",
   "packages/prettier-config-smarthr": "1.0.1",

--- a/packages/eslint-config-smarthr/CHANGELOG.md
+++ b/packages/eslint-config-smarthr/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [13.12.1](https://github.com/kufu/tamatebako/compare/eslint-config-smarthr-v13.12.0...eslint-config-smarthr-v13.12.1) (2026-04-15)
+
+
+### Bug Fixes
+
+* **eslint-config-smarthr:** eslint-plugin-smarthr 6.11.0に更新 ([#1245](https://github.com/kufu/tamatebako/issues/1245)) ([0d18d5f](https://github.com/kufu/tamatebako/commit/0d18d5f))
+
 ## [13.12.0](https://github.com/kufu/tamatebako/compare/eslint-config-smarthr-v13.11.4...eslint-config-smarthr-v13.12.0) (2026-04-14)
 
 

--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-smarthr",
-  "version": "13.12.0",
+  "version": "13.12.1",
   "description": "A sharable ESLint config for SmartHR",
   "type": "module",
   "exports": {


### PR DESCRIPTION
※ 本来は自動で作成されるリリース用PRですが、`chore` コミットだとリリース対象外なのに気づかず、リリースしたい内容を `chore` にしてしまってたので手動作成になります。

リリース内容
---

<details><summary>eslint-config-smarthr: 13.12.1</summary>

## [13.12.1](https://github.com/kufu/tamatebako/compare/eslint-config-smarthr-v13.12.0...eslint-config-smarthr-v13.12.1) (2026-04-15)


### Bug Fixes

* **eslint-config-smarthr:** eslint-plugin-smarthr 6.11.0に更新 ([#1245](https://github.com/kufu/tamatebako/issues/1245)) ([0d18d5f](https://github.com/kufu/tamatebako/commit/0d18d5f))
</details>