### PR TITLE
fix(eslint-config-smarthr): update eslint-plugin-smarthr to 6.12.1

### DIFF
--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-smarthr": "6.11.0",
+    "eslint-plugin-smarthr": "6.12.1",
     "globals": "^17.4.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.11.0
-        version: 6.11.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.12.1
+        version: 6.12.1(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.4.0
         version: 17.4.0
@@ -3989,8 +3989,8 @@ packages:
     peerDependencies:
       eslint: ^9
 
-  eslint-plugin-smarthr@6.11.0:
-    resolution: {integrity: sha512-YjHFCiWCKwGomc2luTB5vn7o2TtbVoIzHGcKtuNuCY2wEKhx8v+Th8QU6LNRF1KQeEldoppv6X3l8bkAffx4nw==}
+  eslint-plugin-smarthr@6.12.1:
+    resolution: {integrity: sha512-lkQZWqtP36N4VJqWlHW1qzXTOIx5rYiYYsjneldwB16LNYGVj4gkBwDB/WfzC6V2TCHtAO0J6mgiVqjtDeYvuw==}
     peerDependencies:
       eslint: ^9
 
@@ -11818,7 +11818,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3
 
-  eslint-plugin-smarthr@6.11.0(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-smarthr@6.12.1(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary
- eslint-config-smarthrのeslint-plugin-smarthr依存関係を6.12.1に更新
- これによりpnpm-lock.yamlの不整合が解消され、CIでのリリースが正常に動作するようになります

## Background
release-pleaseがeslint-plugin-smarthr@6.12.1をリリースした際、eslint-config-smarthrのpackage.jsonは更新されませんでした。その結果、CIで`pnpm install`を実行するとpnpm-lock.yamlが更新され、`lerna publish`がuncommitted changesエラーで失敗していました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)