### PR TITLE
fix(oxlint-config-smarthr): update eslint-plugin-smarthr to >=6.12.1

### DIFF
--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-smarthr": "6.11.0",
+    "eslint-plugin-smarthr": "6.12.1",
     "globals": "^17.4.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -30,6 +30,6 @@
   },
   "peerDependencies": {
     "oxlint": ">=1.0.0",
-    "eslint-plugin-smarthr": ">=6.0.0"
+    "eslint-plugin-smarthr": ">=6.12.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,8 +185,8 @@ importers:
   packages/oxlint-config-smarthr:
     dependencies:
       eslint-plugin-smarthr:
-        specifier: '>=6.0.0'
-        version: 6.10.4(eslint@9.39.4(jiti@2.4.2))
+        specifier: '>=6.12.1'
+        version: 6.12.1(eslint@9.39.4(jiti@2.4.2))
       oxlint:
         specifier: '>=1.0.0'
         version: 1.59.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.11.0
-        version: 6.11.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.12.1
+        version: 6.12.1(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.4.0
         version: 17.4.0
@@ -3989,8 +3989,8 @@ packages:
     peerDependencies:
       eslint: ^9
 
-  eslint-plugin-smarthr@6.11.0:
-    resolution: {integrity: sha512-YjHFCiWCKwGomc2luTB5vn7o2TtbVoIzHGcKtuNuCY2wEKhx8v+Th8QU6LNRF1KQeEldoppv6X3l8bkAffx4nw==}
+  eslint-plugin-smarthr@6.12.1:
+    resolution: {integrity: sha512-lkQZWqtP36N4VJqWlHW1qzXTOIx5rYiYYsjneldwB16LNYGVj4gkBwDB/WfzC6V2TCHtAO0J6mgiVqjtDeYvuw==}
     peerDependencies:
       eslint: ^9
 
@@ -11818,7 +11818,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3
 
-  eslint-plugin-smarthr@6.11.0(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-smarthr@6.12.1(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary
- oxlint-config-smarthrのeslint-plugin-smarthr peerDependencyを>=6.12.1に更新
- これによりv91-to-v92のbutton/anchorButton系変種コンポーネントのsize属性変換修正が反映されます

## Background
eslint-plugin-smarthr@6.12.1でv91-to-v92のbutton/anchorButton系変種コンポーネントのsize属性変換が修正されました。oxlint-config-smarthrのpeerDependenciesを更新することで、この修正が利用できるようになります。

## Related
- #1251 (eslint-plugin-smarthr@6.12.1の修正)
- #1255 (eslint-config-smarthrの更新)

🤖 Generated with [Claude Code](https://claude.com/claude-code)