### PR TITLE
fix: update eslint-config-smarthr to 14.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@commitlint/config-conventional": "^20.5.0",
     "@types/jest": "^30.0.0",
     "eslint": "9.39.4",
-    "eslint-config-smarthr": "13.11.4",
+    "eslint-config-smarthr": "14.0.1",
     "husky": "^9.1.7",
     "jest": "^30.3.0",
     "lerna": "^9.0.7",

--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-smarthr": "6.11.0",
+    "eslint-plugin-smarthr": "6.12.1",
     "globals": "^17.4.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -29,7 +29,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "peerDependencies": {
-    "oxlint": ">=1.0.0",
-    "eslint-plugin-smarthr": ">=6.12.1"
+    "eslint-plugin-smarthr": ">=6.12.1",
+    "oxlint": ">=1.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 9.39.4
         version: 9.39.4(jiti@2.4.2)
       eslint-config-smarthr:
-        specifier: 13.11.4
-        version: 13.11.4(eslint@9.39.4(jiti@2.4.2))(react@19.2.5)(typescript@6.0.2)
+        specifier: 14.0.1
+        version: 14.0.1(eslint@9.39.4(jiti@2.4.2))(react@19.2.5)(typescript@6.0.2)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -3924,8 +3924,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-config-smarthr@13.11.4:
-    resolution: {integrity: sha512-83qyZD54I8xM5KLSQYjY6vEN/YmaGQB5lqaPM9TATgMRUjQ0kQbGZWo202flivl4u9PIQM3aPN8aVdtD1ueKoQ==}
+  eslint-config-smarthr@14.0.1:
+    resolution: {integrity: sha512-kKCyly5Qxd/nQ2nr6xPrmAjU60lOPgbNZw8byp5rj8oO+zbSl4Zy6ZAgiXwYH6lx7YYG6cIYb/JkWj2Rp7Dagg==}
     peerDependencies:
       eslint: ^9.0.0
       react: ^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3982,12 +3982,6 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
-
-  eslint-plugin-smarthr@6.10.4:
-    resolution: {integrity: sha512-ONcDxp+r3zk7tkgaGlcBkcTKg5DqZ+J++rdn1pfM25BUrLYTr7Z/xxIc6LEUYhoPU3MOdDuIE/tB7rOEFeC0FQ==}
-    engines: {node: '>=24.14.1'}
-    peerDependencies:
-      eslint: ^9
 
   eslint-plugin-smarthr@6.12.1:
     resolution: {integrity: sha512-lkQZWqtP36N4VJqWlHW1qzXTOIx5rYiYYsjneldwB16LNYGVj4gkBwDB/WfzC6V2TCHtAO0J6mgiVqjtDeYvuw==}
@@ -11693,7 +11687,7 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
 
-  eslint-config-smarthr@13.11.4(eslint@9.39.4(jiti@2.4.2))(react@19.2.5)(typescript@6.0.2):
+  eslint-config-smarthr@14.0.1(eslint@9.39.4(jiti@2.4.2))(react@19.2.5)(typescript@6.0.2):
     dependencies:
       '@eslint/js': 9.39.4
       '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.4.2))(typescript@6.0.2))(eslint@9.39.4(jiti@2.4.2))(typescript@6.0.2)
@@ -11704,7 +11698,7 @@ snapshots:
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.4.2))
-      eslint-plugin-smarthr: 6.10.4(eslint@9.39.4(jiti@2.4.2))
+      eslint-plugin-smarthr: 6.12.1(eslint@9.39.4(jiti@2.4.2))
       globals: 17.4.0
       react: 19.2.5
       typescript: 6.0.2
@@ -11812,11 +11806,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
-
-  eslint-plugin-smarthr@6.10.4(eslint@9.39.4(jiti@2.4.2)):
-    dependencies:
-      eslint: 9.39.4(jiti@2.4.2)
-      json5: 2.2.3
 
   eslint-plugin-smarthr@6.12.1(eslint@9.39.4(jiti@2.4.2)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.11.0
-        version: 6.11.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.12.1
+        version: 6.12.1(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.4.0
         version: 17.4.0
@@ -3989,8 +3989,8 @@ packages:
     peerDependencies:
       eslint: ^9
 
-  eslint-plugin-smarthr@6.11.0:
-    resolution: {integrity: sha512-YjHFCiWCKwGomc2luTB5vn7o2TtbVoIzHGcKtuNuCY2wEKhx8v+Th8QU6LNRF1KQeEldoppv6X3l8bkAffx4nw==}
+  eslint-plugin-smarthr@6.12.1:
+    resolution: {integrity: sha512-lkQZWqtP36N4VJqWlHW1qzXTOIx5rYiYYsjneldwB16LNYGVj4gkBwDB/WfzC6V2TCHtAO0J6mgiVqjtDeYvuw==}
     peerDependencies:
       eslint: ^9
 
@@ -11818,7 +11818,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3
 
-  eslint-plugin-smarthr@6.11.0(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-smarthr@6.12.1(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary
- ルートのpackage.jsonのeslint-config-smarthrを14.0.1に更新
- これによりpnpm-lock.yamlの不整合が解消され、CIでのリリースが正常に動作するようになります

## Background
release-pleaseがeslint-config-smarthr@14.0.1をリリースした際、ルートのpackage.jsonは更新されませんでした。その結果、CIで`pnpm install`を実行するとpnpm-lock.yamlが13.11.4に基づいて更新され、`lerna publish`がuncommitted changesエラーで失敗していました。

## Root Cause
- `packages/eslint-config-smarthr/package.json`: 14.0.1（リリース済み）
- `package.json`（ルート）: 13.11.4（古いまま） ← **これが原因**
- CIで`pnpm install`実行時に、ルートの指定に基づいてlock fileが更新される

## Related
- https://github.com/kufu/tamatebako/actions/runs/24640206222 (最初の失敗)
- https://github.com/kufu/tamatebako/actions/runs/24641079620 (直近の失敗)

🤖 Generated with [Claude Code](https://claude.com/claude-code)