### PR TITLE
chore: pnpm-lock.yamlの破損を修正

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         version: 19.2.14
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@20.19.40)(jsdom@26.1.0)(vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)(yaml@2.8.1))
+        version: 4.1.5(@types/node@20.19.40)(jsdom@26.1.0)(vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0))
 
   packages/eslint-plugin-smarthr:
     dependencies:
@@ -206,7 +206,7 @@ importers:
         version: 0.7.1(postcss@8.5.14)
       styled-components:
         specifier: ^6.4.1
-        version: 6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.4.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       stylelint:
         specifier: ^17.6.0
         version: 17.6.0(typescript@6.0.3)
@@ -218,7 +218,7 @@ importers:
         version: 40.0.0(stylelint@17.6.0(typescript@6.0.3))
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@20.19.40)(jsdom@26.1.0)(vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)(yaml@2.8.1))
+        version: 4.1.5(@types/node@20.19.40)(jsdom@26.1.0)(vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0))
 
   packages/use-bulk-check:
     devDependencies:
@@ -2949,9 +2949,6 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  camelize@1.0.1:
-    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
-
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
@@ -3099,10 +3096,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-color-keywords@1.0.0:
-    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
-    engines: {node: '>=4'}
-
   css-functions-list@3.3.3:
     resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
     engines: {node: '>=12'}
@@ -3121,9 +3114,6 @@ packages:
 
   css-select@4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
-
-  css-to-react-native@3.2.0:
-    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
@@ -6123,11 +6113,6 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -8507,13 +8492,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.1.5(vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)(yaml@2.8.1)
+      vite: 7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -9011,9 +8996,6 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  camelize@1.0.1:
-    optional: true
-
   caniuse-lite@1.0.30001792: {}
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
@@ -9149,9 +9131,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-color-keywords@1.0.0:
-    optional: true
-
   css-functions-list@3.3.3: {}
 
   css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.5)(esbuild@0.25.12)):
@@ -9174,13 +9153,6 @@ snapshots:
       domhandler: 4.3.1
       domutils: 2.8.0
       nth-check: 2.1.1
-
-  css-to-react-native@3.2.0:
-    dependencies:
-      camelize: 1.0.1
-      css-color-keywords: 1.0.0
-      postcss-value-parser: 4.2.0
-    optional: true
 
   css-tree@3.1.0:
     dependencies:
@@ -11639,7 +11611,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       ansi-styles: 5.2.0
       react-is-18: react-is@18.3.1
-      react-is-19: react-is@19.2.5
+      react-is-19: react-is@19.2.6
 
   process@0.11.10: {}
 
@@ -12162,14 +12134,13 @@ snapshots:
 
   style-search@0.1.0: {}
 
-  styled-components@6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  styled-components@6.4.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@emotion/is-prop-valid': 1.4.0
       csstype: 3.2.3
       react: 19.2.6
       stylis: 4.3.6
     optionalDependencies:
-      css-to-react-native: 3.2.0
       react-dom: 19.2.6(react@19.2.6)
 
   styled-jsx@5.1.1(@babel/core@7.29.0)(react@19.2.6):
@@ -12591,7 +12562,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)(yaml@2.8.1):
+  vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -12604,12 +12575,11 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       terser: 5.36.0
-      yaml: 2.8.1
 
-  vitest@4.1.5(@types/node@20.19.40)(jsdom@26.1.0)(vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)(yaml@2.8.1)):
+  vitest@4.1.5(@types/node@20.19.40)(jsdom@26.1.0)(vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.1.5(vite@7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -12626,7 +12596,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)(yaml@2.8.1)
+      vite: 7.2.1(@types/node@20.19.40)(jiti@2.4.2)(terser@5.36.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.40
@@ -12845,9 +12815,6 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@1.10.2: {}
-
-  yaml@2.8.1:
-    optional: true
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## 概要

PR #1271のマージ後、pnpm-lock.yamlが不整合な状態になり、GitHub Actionsでエラーが発生していた問題を修正します。

## 問題

```
[ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY] Broken lockfile: no entry for 'react-is@19.2.5' in pnpm-lock.yaml
```

`react-is@19.2.5`が参照されているが、packagesセクションに正しく定義されていない状態でした。

## 修正内容

- `pnpm install --no-frozen-lockfile` を実行してlockfileを再生成
- 不要な依存関係を削除（yaml@2.8.1, css-to-react-native等）
- viteとstyled-componentsの依存チェーンを修正

## テスト

- ✅ すべてのテストが成功（1301 tests passed）
- ✅ `pnpm install --frozen-lockfile` でエラーなく動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)