### PR TITLE
fix(ci): リリースワークフローにNPM_TOKEN環境変数を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install
       - run: pnpm release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

npm publishが認証エラーで失敗していた問題を修正します。

## 問題

- `oxlint-config-smarthr` のv0.1.1とv0.1.2の公開に失敗
- エラー: `404 Not Found - PUT https://registry.npmjs.org/oxlint-config-smarthr`
- 原因: npm認証トークンが設定されていない

## 修正内容

release workflowの `pnpm release` ステップに `NODE_AUTH_TOKEN` 環境変数を追加し、GitHub SecretsからNPM_TOKENを読み込むようにしました。

```yaml
- run: pnpm release
  env:
    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

## 前提条件（重要）

このPRをマージする前に、以下の作業が必要です：

### 1. npm Granular Access Tokenの作成

maintainer権限を持つアカウントで以下を実行：

1. https://www.npmjs.com/ にログイン
2. プロフィール → "Access Tokens" → "Generate New Token" → "Granular Access Token"
3. 設定：
   - **Token name**: `GITHUB_ACTIONS_TAMATEBAKO`
   - **Expiration**: 365 days
   - **Packages and scopes**: "Read and write"
   - **Select packages**: 
     - `eslint-config-smarthr`
     - `eslint-plugin-smarthr`
     - `oxlint-config-smarthr`
     - その他公開するすべてのパッケージ

### 2. GitHub Secretsに登録

```bash
gh secret set NPM_TOKEN
# プロンプトでnpmトークンをペースト
```

または GitHub Webから：
https://github.com/kufu/tamatebako/settings/secrets/actions

## テスト

NPM_TOKEN設定後、次回のリリース時に自動的にnpm publishが実行されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)