### PR TITLE
feat: best-practice-for-consecutive-definition-listルールを追加

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/README.md
@@ -4,7 +4,7 @@
 
 `DefinitionList` コンポーネントが同じ親要素の直下に連続して配置されている場合、多くのケースで誤った使い方をしている可能性があります。
 
-以前は異なるカラム数（1カラム・2カラムなど）を表現するために複数の `DefinitionList` を使う必要がありましたが、現在は `DefinitionListItem` の `maxColumns` prop を使用することで、1つの `DefinitionList` 内で異なるカラム数を混在させることができます。
+`DefinitionListItem` の `maxColumns` prop を使用することで、1つの `DefinitionList` 内で異なるカラム数を混在させることができます。
 
 ## rules
 

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/README.md
@@ -1,0 +1,68 @@
+# best-practice-for-consecutive-definition-list
+
+同階層に `DefinitionList` が連続して配置されている場合に警告します。
+
+## ルールの詳細
+
+`DefinitionList` コンポーネントが同じ親要素の直下に連続して配置されている場合、多くのケースで誤った使い方をしている可能性があります。
+
+以前は異なるカラム数（1カラム・2カラムなど）を表現するために複数の `DefinitionList` を使う必要がありましたが、現在は `DefinitionListItem` の `maxColumns` prop を使用することで、1つの `DefinitionList` 内で異なるカラム数を混在させることができます。
+
+## 👎 間違った例
+
+```tsx
+// ❌ DefinitionListが連続している
+<DefinitionList>
+  <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+</DefinitionList>
+<DefinitionList>
+  <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+  <DefinitionListItem term="項目3">内容3</DefinitionListItem>
+</DefinitionList>
+```
+
+## 👍 正しい例
+
+```tsx
+// ✅ 1つのDefinitionListにまとめる
+<DefinitionList>
+  <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+  <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+  <DefinitionListItem term="項目3">内容3</DefinitionListItem>
+</DefinitionList>
+
+// ✅ maxColumns を使用してカラム数を指定
+<DefinitionList>
+  <DefinitionListItem maxColumns={1} term="項目1">内容1</DefinitionListItem>
+  <DefinitionListItem maxColumns={2} term="項目2">内容2</DefinitionListItem>
+  <DefinitionListItem maxColumns={2} term="項目3">内容3</DefinitionListItem>
+</DefinitionList>
+
+// ✅ 意味的に異なるグループを表現する場合は、間に別の要素を挿入
+<DefinitionList>
+  <DefinitionListItem term="基本情報">...</DefinitionListItem>
+</DefinitionList>
+
+<h2>詳細情報</h2>
+
+<DefinitionList>
+  <DefinitionListItem term="詳細項目">...</DefinitionListItem>
+</DefinitionList>
+```
+
+## 例外
+
+以下のようなケースでは、複数の `DefinitionList` を使用しても問題ありません：
+
+- 意味的に明確に異なるグループを表現する場合（間に見出しなどの要素を挟む）
+- 異なるスタイリングやレイアウトが必要な場合
+- セマンティック上、別の定義リストとして扱うべき場合
+
+## autofix
+
+このルールは自動修正に対応していません。手動で修正してください。
+
+## 参考
+
+- [DefinitionListItem - maxColumns](https://github.com/kufu/smarthr-ui/blob/master/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx)
+- [Storybook - DefinitionListItem MaxColumns](https://github.com/kufu/smarthr-ui/blob/master/packages/smarthr-ui/src/components/DefinitionList/stories/DefinitionListItem.stories.tsx)

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/README.md
@@ -1,17 +1,24 @@
-# best-practice-for-consecutive-definition-list
+# smarthr/best-practice-for-consecutive-definition-list
 
-同階層に `DefinitionList` が連続して配置されている場合に警告します。
-
-## ルールの詳細
+同階層に `DefinitionList` が連続して配置されている場合に警告するルールです。
 
 `DefinitionList` コンポーネントが同じ親要素の直下に連続して配置されている場合、多くのケースで誤った使い方をしている可能性があります。
 
 以前は異なるカラム数（1カラム・2カラムなど）を表現するために複数の `DefinitionList` を使う必要がありましたが、現在は `DefinitionListItem` の `maxColumns` prop を使用することで、1つの `DefinitionList` 内で異なるカラム数を混在させることができます。
 
-## 👎 間違った例
+## rules
+
+```js
+{
+  rules: {
+    'smarthr/best-practice-for-consecutive-definition-list': 'error', // 'warn', 'off'
+  },
+}
+```
+
+## ❌ Incorrect
 
 ```tsx
-// ❌ DefinitionListが連続している
 <DefinitionList>
   <DefinitionListItem term="項目1">内容1</DefinitionListItem>
 </DefinitionList>
@@ -21,24 +28,28 @@
 </DefinitionList>
 ```
 
-## 👍 正しい例
+## ✅ Correct
 
 ```tsx
-// ✅ 1つのDefinitionListにまとめる
+// 1つのDefinitionListにまとめる
 <DefinitionList>
   <DefinitionListItem term="項目1">内容1</DefinitionListItem>
   <DefinitionListItem term="項目2">内容2</DefinitionListItem>
   <DefinitionListItem term="項目3">内容3</DefinitionListItem>
 </DefinitionList>
+```
 
-// ✅ maxColumns を使用してカラム数を指定
+```tsx
+// maxColumns を使用してカラム数を指定
 <DefinitionList>
   <DefinitionListItem maxColumns={1} term="項目1">内容1</DefinitionListItem>
   <DefinitionListItem maxColumns={2} term="項目2">内容2</DefinitionListItem>
   <DefinitionListItem maxColumns={2} term="項目3">内容3</DefinitionListItem>
 </DefinitionList>
+```
 
-// ✅ 意味的に異なるグループを表現する場合は、間に別の要素を挿入
+```tsx
+// 意味的に異なるグループを表現する場合は、間に別の要素を挿入
 <DefinitionList>
   <DefinitionListItem term="基本情報">...</DefinitionListItem>
 </DefinitionList>
@@ -50,17 +61,9 @@
 </DefinitionList>
 ```
 
-## 例外
-
-以下のようなケースでは、複数の `DefinitionList` を使用しても問題ありません：
-
-- 意味的に明確に異なるグループを表現する場合（間に見出しなどの要素を挟む）
-- 異なるスタイリングやレイアウトが必要な場合
-- セマンティック上、別の定義リストとして扱うべき場合
-
 ## autofix
 
-このルールは自動修正に対応していません。手動で修正してください。
+このルールは自動修正に対応していません。
 
 ## 参考
 

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
@@ -40,7 +40,7 @@ module.exports = {
   },
   create(context) {
     return {
-      'JSXElement[openingElement.name.name=/DefinitionList$/]'(node) {
+      [`JSXElement[openingElement.name.name=${DEFINITION_LIST_PATTERN}]`](node) {
         const prev = getPreviousSibling(node)
 
         if (

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
@@ -16,13 +16,10 @@ const getPreviousSibling = (node) => {
   for (let i = currentIndex - 1; i >= 0; i--) {
     const child = children[i]
 
-    // 空白JSXText スキップ
-    if (child.type === 'JSXText' && child.value.trim() === '') continue
-
-    // JSXコメント {/* ... */} スキップ
+    // 空白JSXText or JSXコメント スキップ
     if (
-      child.type === 'JSXExpressionContainer' &&
-      child.expression.type === 'JSXEmptyExpression'
+      (child.type === 'JSXText' && child.value.trim() === '') ||
+      (child.type === 'JSXExpressionContainer' && child.expression.type === 'JSXEmptyExpression')
     ) {
       continue
     }
@@ -43,19 +40,17 @@ module.exports = {
       [`JSXElement[openingElement.name.name=${DEFINITION_LIST_PATTERN}]`](node) {
         const prev = getPreviousSibling(node)
 
-        if (
-          prev?.type === 'JSXElement' &&
-          prev.openingElement.name.type === 'JSXIdentifier' &&
-          DEFINITION_LIST_PATTERN.test(prev.openingElement.name.name)
-        ) {
-          context.report({
-            node: node.openingElement.name,
-            message: `DefinitionList が連続しています
+        if (!prev || prev.type !== 'JSXElement') return
+        if (prev.openingElement.name.type !== 'JSXIdentifier') return
+        if (!DEFINITION_LIST_PATTERN.test(prev.openingElement.name.name)) return
+
+        context.report({
+          node: node.openingElement.name,
+          message: `DefinitionList が連続しています
  - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list
  - DefinitionListItem の maxColumns prop を使用して1つにまとめることを検討してください
  - 例外: 意味的に異なるグループの場合は複数のDefinitionListを使用しても問題ありません`,
-          })
-        }
+        })
       },
     }
   },

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
@@ -1,0 +1,59 @@
+/**
+ * @type {import('@typescript-eslint/utils').TSESLint.RuleModule<''>}
+ */
+
+const getPreviousSibling = (node) => {
+  const parent = node.parent
+  if (!parent || (parent.type !== 'JSXElement' && parent.type !== 'JSXFragment')) {
+    return null
+  }
+
+  const children = parent.children || []
+  const currentIndex = children.indexOf(node)
+
+  for (let i = currentIndex - 1; i >= 0; i--) {
+    const child = children[i]
+
+    // 空白のJSXText or falsy値のJSXExpressionContainer スキップ
+    if (child.type === 'JSXText' && child.value.trim() === '') continue
+    if (
+      child.type === 'JSXExpressionContainer' &&
+      child.expression.type === 'Identifier' &&
+      ['undefined', 'null', 'false'].includes(child.expression.name)
+    ) {
+      continue
+    }
+
+    return child
+  }
+
+  return null
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    schema: [],
+  },
+  create(context) {
+    return {
+      'JSXElement[openingElement.name.name="DefinitionList"]'(node) {
+        const prev = getPreviousSibling(node)
+
+        if (
+          prev?.type === 'JSXElement' &&
+          prev.openingElement.name.type === 'JSXIdentifier' &&
+          prev.openingElement.name.name === 'DefinitionList'
+        ) {
+          context.report({
+            node: node.openingElement.name,
+            message: `DefinitionList が連続しています
+ - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list
+ - DefinitionListItem の maxColumns prop を使用して1つにまとめることを検討してください
+ - 例外: 意味的に異なるグループの場合は複数のDefinitionListを使用しても問題ありません`,
+          })
+        }
+      },
+    }
+  },
+}

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
@@ -38,21 +38,19 @@ module.exports = {
         const prev = getPreviousSibling(node)
 
         if (
-          !prev ||
-          prev.type !== 'JSXElement' ||
-          prev.openingElement.name.type !== 'JSXIdentifier' ||
-          !DEFINITION_LIST_PATTERN.test(prev.openingElement.name.name)
+          prev &&
+          prev.type === 'JSXElement' &&
+          prev.openingElement.name.type === 'JSXIdentifier' &&
+          DEFINITION_LIST_PATTERN.test(prev.openingElement.name.name)
         ) {
-          return
-        }
-
-        context.report({
-          node: node.openingElement.name,
-          message: `DefinitionList が連続しています
+          context.report({
+            node: node.openingElement.name,
+            message: `DefinitionList が連続しています
  - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list
  - DefinitionListItem の maxColumns prop を使用して1つにまとめることを検討してください
  - 例外: 意味的に異なるグループの場合は複数のDefinitionListを使用しても問題ありません`,
-        })
+          })
+        }
       },
     }
   },

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
@@ -14,7 +14,6 @@ const getPreviousSibling = (node) => {
   for (let i = currentIndex - 1; i >= 0; i--) {
     const child = children[i]
 
-    // 空白のJSXText or falsy値のJSXExpressionContainer スキップ
     if (child.type === 'JSXText' && child.value.trim() === '') continue
     if (
       child.type === 'JSXExpressionContainer' &&
@@ -37,13 +36,13 @@ module.exports = {
   },
   create(context) {
     return {
-      'JSXElement[openingElement.name.name="DefinitionList"]'(node) {
+      'JSXElement[openingElement.name.name=/DefinitionList$/]'(node) {
         const prev = getPreviousSibling(node)
 
         if (
           prev?.type === 'JSXElement' &&
           prev.openingElement.name.type === 'JSXIdentifier' &&
-          prev.openingElement.name.name === 'DefinitionList'
+          /DefinitionList$/.test(prev.openingElement.name.name)
         ) {
           context.report({
             node: node.openingElement.name,

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
@@ -2,6 +2,8 @@
  * @type {import('@typescript-eslint/utils').TSESLint.RuleModule<''>}
  */
 
+const DEFINITION_LIST_PATTERN = /DefinitionList$/
+
 const getPreviousSibling = (node) => {
   const parent = node.parent
   if (!parent || (parent.type !== 'JSXElement' && parent.type !== 'JSXFragment')) {
@@ -44,7 +46,7 @@ module.exports = {
         if (
           prev?.type === 'JSXElement' &&
           prev.openingElement.name.type === 'JSXIdentifier' &&
-          /DefinitionList$/.test(prev.openingElement.name.name)
+          DEFINITION_LIST_PATTERN.test(prev.openingElement.name.name)
         ) {
           context.report({
             node: node.openingElement.name,

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
@@ -14,8 +14,16 @@ const getPreviousSibling = (node) => {
   for (let i = currentIndex - 1; i >= 0; i--) {
     const child = children[i]
 
-    // 空白JSXText のみスキップ
+    // 空白JSXText スキップ
     if (child.type === 'JSXText' && child.value.trim() === '') continue
+
+    // JSXコメント {/* ... */} スキップ
+    if (
+      child.type === 'JSXExpressionContainer' &&
+      child.expression.type === 'JSXEmptyExpression'
+    ) {
+      continue
+    }
 
     return child
   }

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
@@ -16,15 +16,12 @@ const getPreviousSibling = (node) => {
   for (let i = currentIndex - 1; i >= 0; i--) {
     const child = children[i]
 
-    // 空白JSXText or JSXコメント スキップ
     if (
-      (child.type === 'JSXText' && child.value.trim() === '') ||
-      (child.type === 'JSXExpressionContainer' && child.expression.type === 'JSXEmptyExpression')
+      (child.type !== 'JSXText' || child.value.trim() !== '') &&
+      (child.type !== 'JSXExpressionContainer' || child.expression.type !== 'JSXEmptyExpression')
     ) {
-      continue
+      return child
     }
-
-    return child
   }
 
   return null
@@ -40,9 +37,14 @@ module.exports = {
       [`JSXElement[openingElement.name.name=${DEFINITION_LIST_PATTERN}]`](node) {
         const prev = getPreviousSibling(node)
 
-        if (!prev || prev.type !== 'JSXElement') return
-        if (prev.openingElement.name.type !== 'JSXIdentifier') return
-        if (!DEFINITION_LIST_PATTERN.test(prev.openingElement.name.name)) return
+        if (
+          !prev ||
+          prev.type !== 'JSXElement' ||
+          prev.openingElement.name.type !== 'JSXIdentifier' ||
+          !DEFINITION_LIST_PATTERN.test(prev.openingElement.name.name)
+        ) {
+          return
+        }
 
         context.report({
           node: node.openingElement.name,

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
@@ -37,12 +37,7 @@ module.exports = {
       [`JSXElement[openingElement.name.name=${DEFINITION_LIST_PATTERN}]`](node) {
         const prev = getPreviousSibling(node)
 
-        if (
-          prev &&
-          prev.type === 'JSXElement' &&
-          prev.openingElement.name.type === 'JSXIdentifier' &&
-          DEFINITION_LIST_PATTERN.test(prev.openingElement.name.name)
-        ) {
+        if (prev?.type === 'JSXElement' && DEFINITION_LIST_PATTERN.test(prev.openingElement.name.name)) {
           context.report({
             node: node.openingElement.name,
             message: `DefinitionList が連続しています

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-consecutive-definition-list/index.js
@@ -14,14 +14,8 @@ const getPreviousSibling = (node) => {
   for (let i = currentIndex - 1; i >= 0; i--) {
     const child = children[i]
 
+    // 空白JSXText のみスキップ
     if (child.type === 'JSXText' && child.value.trim() === '') continue
-    if (
-      child.type === 'JSXExpressionContainer' &&
-      child.expression.type === 'Identifier' &&
-      ['undefined', 'null', 'false'].includes(child.expression.name)
-    ) {
-      continue
-    }
 
     return child
   }

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-consecutive-definition-list.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-consecutive-definition-list.js
@@ -1,0 +1,157 @@
+const rule = require('../rules/best-practice-for-consecutive-definition-list')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+ruleTester.run('best-practice-for-consecutive-definition-list', rule, {
+  valid: [
+    // 単一の DefinitionList
+    {
+      code: `
+        <DefinitionList>
+          <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+        </DefinitionList>
+      `,
+    },
+    // DefinitionList が連続していない
+    {
+      code: `
+        <div>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+          <p>テキスト</p>
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+        </div>
+      `,
+    },
+    // maxColumns を使用して1つにまとめている
+    {
+      code: `
+        <DefinitionList>
+          <DefinitionListItem maxColumns={1} term="項目1">内容1</DefinitionListItem>
+          <DefinitionListItem maxColumns={2} term="項目2">内容2</DefinitionListItem>
+        </DefinitionList>
+      `,
+    },
+    // Fragment 内で単一
+    {
+      code: `
+        <>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+        </>
+      `,
+    },
+    // 異なる階層
+    {
+      code: `
+        <>
+          <div>
+            <DefinitionList>
+              <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+            </DefinitionList>
+          </div>
+          <div>
+            <DefinitionList>
+              <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+            </DefinitionList>
+          </div>
+        </>
+      `,
+    },
+  ],
+
+  invalid: [
+    // DefinitionList が連続している
+    {
+      code: `
+        <div>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+        </div>
+      `,
+      errors: [
+        {
+          message: /DefinitionList が連続しています/,
+        },
+      ],
+    },
+    // 3つ連続
+    {
+      code: `
+        <div>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+          <DefinitionList>
+            <DefinitionListItem term="項目3">内容3</DefinitionListItem>
+          </DefinitionList>
+        </div>
+      `,
+      errors: [
+        {
+          message: /DefinitionList が連続しています/,
+        },
+        {
+          message: /DefinitionList が連続しています/,
+        },
+      ],
+    },
+    // Fragment 内で連続
+    {
+      code: `
+        <>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+        </>
+      `,
+      errors: [
+        {
+          message: /DefinitionList が連続しています/,
+        },
+      ],
+    },
+    // 空白が間にある場合
+    {
+      code: `
+        <div>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+        </div>
+      `,
+      errors: [
+        {
+          message: /DefinitionList が連続しています/,
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-consecutive-definition-list.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-consecutive-definition-list.js
@@ -71,6 +71,76 @@ ruleTester.run('best-practice-for-consecutive-definition-list', rule, {
         </>
       `,
     },
+    // 間に条件式がある場合
+    {
+      code: `
+        <div>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+          {condition && <p>条件付き要素</p>}
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+        </div>
+      `,
+    },
+    // 間に配列mapがある場合
+    {
+      code: `
+        <div>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+          {items.map(item => <div key={item.id}>{item.name}</div>)}
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+        </div>
+      `,
+    },
+    // 間にfalse式がある場合（レンダリングされないが式なので連続扱いしない）
+    {
+      code: `
+        <div>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+          {false}
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+        </div>
+      `,
+    },
+    // 間にnull式がある場合（レンダリングされないが式なので連続扱いしない）
+    {
+      code: `
+        <div>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+          {null}
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+        </div>
+      `,
+    },
+    // 間にundefined式がある場合（レンダリングされないが式なので連続扱いしない）
+    {
+      code: `
+        <div>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+          {undefined}
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+        </div>
+      `,
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-consecutive-definition-list.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-consecutive-definition-list.js
@@ -223,5 +223,24 @@ ruleTester.run('best-practice-for-consecutive-definition-list', rule, {
         },
       ],
     },
+    // 間にコメントがある場合（スキップされるので連続扱い）
+    {
+      code: `
+        <div>
+          <DefinitionList>
+            <DefinitionListItem term="項目1">内容1</DefinitionListItem>
+          </DefinitionList>
+          {/* コメント */}
+          <DefinitionList>
+            <DefinitionListItem term="項目2">内容2</DefinitionListItem>
+          </DefinitionList>
+        </div>
+      `,
+      errors: [
+        {
+          message: /DefinitionList が連続しています/,
+        },
+      ],
+    },
   ],
 })


### PR DESCRIPTION
## 概要

同階層 連続DefinitionList 検出ルール。

## 問題

DefinitionList 連続配置 = 多くの場合 誤用。
現在 DefinitionListItem `maxColumns` で 1つのDefinitionList内 カラム数混在可能。

## 実装

- ✅ 連続DefinitionList 検出
- ✅ ESLint Selector `/DefinitionList$/` で拡張対応
- ✅ 間にJSXExpression → 連続扱いしない
- ✅ テスト 14件 全通過

## 使用例

```tsx
// ❌ エラー
<DefinitionList>
  <DefinitionListItem term="項目1">内容1</DefinitionListItem>
</DefinitionList>
<DefinitionList>
  <DefinitionListItem term="項目2">内容2</DefinitionListItem>
</DefinitionList>

// ✅ OK - 1つにまとめる
<DefinitionList>
  <DefinitionListItem term="項目1">内容1</DefinitionListItem>
  <DefinitionListItem term="項目2">内容2</DefinitionListItem>
</DefinitionList>

// ✅ OK - maxColumns 指定
<DefinitionList>
  <DefinitionListItem maxColumns={1} term="項目1">内容1</DefinitionListItem>
  <DefinitionListItem maxColumns={2} term="項目2">内容2</DefinitionListItem>
</DefinitionList>

// ✅ OK - 間に別要素
<DefinitionList>
  <DefinitionListItem term="基本情報">...</DefinitionListItem>
</DefinitionList>

<h2>詳細情報</h2>

<DefinitionList>
  <DefinitionListItem term="詳細項目">...</DefinitionListItem>
</DefinitionList>

// ✅ OK - 間に条件式
<DefinitionList>
  <DefinitionListItem term="項目1">内容1</DefinitionListItem>
</DefinitionList>
{condition && <p>条件付き要素</p>}
<DefinitionList>
  <DefinitionListItem term="項目2">内容2</DefinitionListItem>
</DefinitionList>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)