### PR TITLE
feat(eslint-config-smarthr): eslint-plugin-smarthrを6.15.0に更新

### DIFF
--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -55,8 +55,10 @@ export default [
       'smarthr/a11y-trigger-has-button': 'error',
       'smarthr/best-practice-for-async-current-target': 'error',
       'smarthr/best-practice-for-button-element': 'error',
+      'smarthr/best-practice-for-consecutive-definition-list': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
       'smarthr/best-practice-for-date': 'error',
       'smarthr/best-practice-for-data-test-attribute': 'off',
+      'smarthr/best-practice-for-default-props': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
       'smarthr/best-practice-for-interactive-element': 'error',
       'smarthr/best-practice-for-layouts': 'error',
       'smarthr/best-practice-for-nested-attributes-array-index': 'error',

--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-smarthr": "6.14.0",
+    "eslint-plugin-smarthr": "6.15.0",
     "globals": "^17.6.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
@@ -3039,11 +3039,17 @@ exports[`should match ESLint Configuration snapshot 1`] = `
     "smarthr/best-practice-for-button-element": [
       2,
     ],
+    "smarthr/best-practice-for-consecutive-definition-list": [
+      1,
+    ],
     "smarthr/best-practice-for-data-test-attribute": [
       0,
     ],
     "smarthr/best-practice-for-date": [
       2,
+    ],
+    "smarthr/best-practice-for-default-props": [
+      1,
     ],
     "smarthr/best-practice-for-interactive-element": [
       2,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.14.0
-        version: 6.14.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.15.0
+        version: 6.15.0(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -3476,6 +3476,11 @@ packages:
 
   eslint-plugin-smarthr@6.14.0:
     resolution: {integrity: sha512-s5UPhg6XT1GRhbKG9xFaPTt1c+JkyFAC3SfNxO5BnrPKUVnXZBQ7qWNXbth5qb3qEAYJm4M+ZExc60MC+uQJzQ==}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.15.0:
+    resolution: {integrity: sha512-4AgqU7lDd6lOa2DOt4v5P+K96CSLVGyPTMpWNznJ2oiZHhrSoZ6O65vrIxoQGB/OW+81czrKplMTcwR9GoYXGg==}
     peerDependencies:
       eslint: ^9
 
@@ -9744,6 +9749,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.14.0(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.15.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## 概要

eslint-config-smarthrで使用するeslint-plugin-smarthrを6.15.0に更新。

## 更新内容

eslint-plugin-smarthr v6.15.0の新機能:
- v93-to-v94 migrator追加（ThCheckbox decorators削除対応）
- best-practice-for-consecutive-definition-list ルール追加
- best-practice-for-default-props ルール追加
- 同階層バレルファイル間import禁止ルール追加

## テスト

✅ 1件全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)