### PR TITLE
feat(oxlint-config-smarthr): eslint-plugin-smarthrを6.15.0に更新

### DIFF
--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -217,8 +217,10 @@ const config = {
     'eslint-plugin-smarthr/a11y-trigger-has-button': 'error',
     'eslint-plugin-smarthr/best-practice-for-async-current-target': 'error',
     'eslint-plugin-smarthr/best-practice-for-button-element': 'error',
+    'eslint-plugin-smarthr/best-practice-for-consecutive-definition-list': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
     'eslint-plugin-smarthr/best-practice-for-date': 'error',
     'eslint-plugin-smarthr/best-practice-for-data-test-attribute': 'off',
+    'eslint-plugin-smarthr/best-practice-for-default-props': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
     'eslint-plugin-smarthr/best-practice-for-interactive-element': 'error',
     'eslint-plugin-smarthr/best-practice-for-layouts': 'error',
     'eslint-plugin-smarthr/best-practice-for-nested-attributes-array-index': 'error',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,7 +183,7 @@ importers:
     dependencies:
       eslint-plugin-smarthr:
         specifier: '>=6.14.0'
-        version: 6.14.0(eslint@9.39.4(jiti@2.4.2))
+        version: 6.15.0(eslint@9.39.4(jiti@2.4.2))
       oxlint:
         specifier: '>=1.0.0'
         version: 1.59.0
@@ -3476,6 +3476,11 @@ packages:
 
   eslint-plugin-smarthr@6.14.0:
     resolution: {integrity: sha512-s5UPhg6XT1GRhbKG9xFaPTt1c+JkyFAC3SfNxO5BnrPKUVnXZBQ7qWNXbth5qb3qEAYJm4M+ZExc60MC+uQJzQ==}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.15.0:
+    resolution: {integrity: sha512-4AgqU7lDd6lOa2DOt4v5P+K96CSLVGyPTMpWNznJ2oiZHhrSoZ6O65vrIxoQGB/OW+81czrKplMTcwR9GoYXGg==}
     peerDependencies:
       eslint: ^9
 
@@ -9744,6 +9749,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.14.0(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.15.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## 概要

oxlint-config-smarthrで使用するeslint-plugin-smarthrを6.15.0に更新。

## 更新内容

eslint-plugin-smarthr v6.15.0の新機能:
- v93-to-v94 migrator追加（ThCheckbox decorators削除対応）
- best-practice-for-consecutive-definition-list ルール追加
- best-practice-for-default-props ルール追加
- 同階層バレルファイル間import禁止ルール追加

## テスト

✅ oxlint設定検証通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)