### PR TITLE
feat: InformationPanelを白背景に配置することを禁止するルールを追加

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/README.md
+++ b/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/README.md
@@ -1,0 +1,163 @@
+# smarthr/design-system-guideline-prohibit-information-panel-in-white-bg
+
+InformationPanelを白背景に配置することを禁止します。
+
+## なぜこのルールが必要か
+
+SmartHR Design Systemのガイドラインに基づき、InformationPanelは白背景に直接配置すべきではありません。
+
+**理由:**
+- InformationPanelのレイヤー順序は3です
+- Baseのレイヤー順序は1です
+- 視覚的に適切な階層関係を保つため、白背景の上に直接配置することは避けるべきです
+
+詳細: https://smarthr.design/products/components/information-panel/#h3-1
+
+## 検出パターン
+
+このルールは以下のパターンを検出します:
+
+### 1. Base内にInformationPanel
+
+```tsx
+// ❌ Bad
+<Base>
+  <InformationPanel>情報</InformationPanel>
+</Base>
+
+<Base>
+  <div>
+    <InformationPanel>情報</InformationPanel>
+  </div>
+</Base>
+```
+
+### 2. Dialog内にInformationPanel（白背景）
+
+contentBgColorが未指定、または"WHITE"が指定されている場合:
+
+```tsx
+// ❌ Bad
+<ActionDialog>
+  <InformationPanel>情報</InformationPanel>
+</ActionDialog>
+
+<FormDialog contentBgColor="WHITE">
+  <InformationPanel>情報</InformationPanel>
+</FormDialog>
+```
+
+## 例外
+
+以下の場合はエラーになりません:
+
+### BaseColumn内にある場合
+
+BaseColumnは背景色を持つため、その中にInformationPanelを配置することは問題ありません:
+
+```tsx
+// ✅ Good
+<Base>
+  <BaseColumn>
+    <InformationPanel>情報</InformationPanel>
+  </BaseColumn>
+</Base>
+```
+
+### DialogでcontentBgColorが指定されている場合
+
+```tsx
+// ✅ Good
+<ActionDialog contentBgColor="COLUMN">
+  <InformationPanel>情報</InformationPanel>
+</ActionDialog>
+
+<FormDialog contentBgColor="OVER_BACKGROUND">
+  <InformationPanel>情報</InformationPanel>
+</FormDialog>
+```
+
+## 正しい使用例
+
+```tsx
+// ✅ Good: Stack/Clusterなどレイアウトコンポーネントで包む
+<Stack>
+  <InformationPanel>情報</InformationPanel>
+</Stack>
+
+<Cluster>
+  <InformationPanel>情報</InformationPanel>
+</Cluster>
+
+// ✅ Good: BaseColumnを使用
+<Base>
+  <BaseColumn>
+    <InformationPanel>情報</InformationPanel>
+  </BaseColumn>
+</Base>
+
+// ✅ Good: DialogでcontentBgColorを指定
+<ActionDialog contentBgColor="COLUMN">
+  <InformationPanel>情報</InformationPanel>
+</ActionDialog>
+
+// ✅ Good: Base外で使用
+<InformationPanel>情報</InformationPanel>
+```
+
+## 誤った使用例
+
+```tsx
+// ❌ Bad: Base内に直接配置
+<Base>
+  <InformationPanel>情報</InformationPanel>
+</Base>
+
+// ❌ Bad: Base内の他要素の中に配置
+<Base>
+  <div>
+    <InformationPanel>情報</InformationPanel>
+  </div>
+</Base>
+
+// ❌ Bad: DialogでcontentBgColorが未指定
+<ActionDialog>
+  <InformationPanel>情報</InformationPanel>
+</ActionDialog>
+
+// ❌ Bad: DialogでcontentBgColor="WHITE"
+<FormDialog contentBgColor="WHITE">
+  <InformationPanel>情報</InformationPanel>
+</FormDialog>
+```
+
+## よくある間違い
+
+### DialogContents内に配置
+
+DialogContents（Dialog内部のコンテンツ領域）はデフォルトで白背景です。そのため、以下のようなコードはエラーになります:
+
+```tsx
+// ❌ Bad
+<ActionDialog>
+  <InformationPanel>情報</InformationPanel>
+</ActionDialog>
+```
+
+**解決方法:**
+1. contentBgColorを指定する（推奨）
+2. BaseColumnで包む
+
+```tsx
+// ✅ Good: contentBgColorを指定
+<ActionDialog contentBgColor="OVER_BACKGROUND">
+  <InformationPanel>情報</InformationPanel>
+</ActionDialog>
+
+// ✅ Good: BaseColumnで包む
+<ActionDialog>
+  <BaseColumn>
+    <InformationPanel>情報</InformationPanel>
+  </BaseColumn>
+</ActionDialog>
+```

--- a/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
+++ b/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
@@ -18,7 +18,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     messages: {
-      inWhiteBg: 'InformationPanelを白背景に配置しないでください。Stack/Clusterなどレイアウトコンポーネントで包むか、BaseColumnを使用、またはDialog使用時はcontentBgColorを"COLUMN"や"OVER_BACKGROUND"に設定してください。詳細: https://smarthr.design/products/components/information-panel/',
+      inWhiteBg: 'InformationPanelを白背景に配置しないでください。BaseColumnを使用で包むか、またはDialog使用時はcontentBgColorを"COLUMN"や"OVER_BACKGROUND"に設定してください。詳細: https://smarthr.design/products/components/information-panel/',
     },
     schema: [],
   },

--- a/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
+++ b/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
@@ -1,0 +1,90 @@
+/**
+ * InformationPanelを白背景に配置することを禁止するルール
+ *
+ * SmartHR Design System ガイドラインに基づき、InformationPanelを白背景に直接配置することを防ぎます。
+ *
+ * 検出パターン:
+ * 1. Base内にInformationPanel
+ * 2. Dialog内にInformationPanel（contentBgColorが未指定またはWHITE）
+ *
+ * 例外:
+ * - BaseColumn内にある場合（BaseColumnは背景色を持つため）
+ * - DialogでcontentBgColorがWHITE以外の場合
+ *
+ * @see https://smarthr.design/products/components/information-panel/
+ */
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'InformationPanelを白背景に配置することを禁止します',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    messages: {
+      inWhiteBg: 'InformationPanelを白背景に配置しないでください。Stack/Clusterなどレイアウトコンポーネントで包むか、BaseColumnを使用、またはDialog使用時はcontentBgColorを"COLUMN"や"OVER_BACKGROUND"に設定してください。詳細: https://smarthr.design/products/components/information-panel/',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    /**
+     * InformationPanelから親方向に探索し、白背景コンテナをチェック
+     * @param {Node} node - InformationPanelのノード
+     * @param {string|RegExp} targetPattern - 検出対象のコンポーネント名パターン
+     * @returns {{ ok: boolean, targetNode?: Node }} 検出結果
+     */
+    const checkWhiteBg = (node, targetPattern) => {
+      let current = node.parent
+      while (current) {
+        if (current.type === 'JSXElement') {
+          const name = current.openingElement.name.name
+
+          // BaseColumnが見つかったらOK（探索終了）
+          if (name === 'BaseColumn') {
+            return { ok: true }
+          }
+
+          // targetパターンにマッチするか確認
+          const isTarget = typeof targetPattern === 'string'
+            ? name === targetPattern
+            : targetPattern.test(name)
+
+          if (isTarget) {
+            return { ok: false, targetNode: current }
+          }
+        }
+        current = current.parent
+      }
+      return { ok: true } // 何も見つからない場合はOK
+    }
+
+    return {
+      // Base以下のInformationPanel
+      'JSXElement[openingElement.name.name="Base"] JSXElement[openingElement.name.name="InformationPanel"]'(node) {
+        const result = checkWhiteBg(node, 'Base')
+        if (!result.ok) {
+          context.report({ node, messageId: 'inWhiteBg' })
+        }
+      },
+
+      // Dialog以下のInformationPanel
+      'JSXElement[openingElement.name.name=/Dialog$/] JSXElement[openingElement.name.name="InformationPanel"]'(node) {
+        const result = checkWhiteBg(node, /Dialog$/)
+        if (!result.ok) {
+          // contentBgColor属性をチェック
+          const attr = result.targetNode.openingElement.attributes.find(
+            a => a.type === 'JSXAttribute' && a.name.name === 'contentBgColor'
+          )
+          const bgColor = attr?.value?.value
+
+          // contentBgColorが未指定またはWHITEの場合のみエラー
+          if (!bgColor || bgColor === 'WHITE') {
+            context.report({ node, messageId: 'inWhiteBg' })
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
+++ b/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
@@ -18,7 +18,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     messages: {
-      inWhiteBg: 'InformationPanelを白背景に配置しないでください。BaseColumnを使用で包むか、またはDialog使用時はcontentBgColorを"COLUMN"や"OVER_BACKGROUND"に設定してください。詳細: https://smarthr.design/products/components/information-panel/',
+      inWhiteBg: 'InformationPanelを白背景に配置しないでください。BaseColumnで包むか、Dialog使用時はcontentBgColorを"COLUMN"や"OVER_BACKGROUND"に設定してください。詳細: https://smarthr.design/products/components/information-panel/',
     },
     schema: [],
   },

--- a/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
+++ b/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
@@ -18,7 +18,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     messages: {
-      inWhiteBg: 'InformationPanelを白背景に配置しないでください。InformationPanelをBaseColumnで包むか、Dialog使用時はcontentBgColorを"COLUMN"や"OVER_BACKGROUND"に設定してください。詳細: https://smarthr.design/products/components/information-panel/',
+      inWhiteBg: 'InformationPanelを白背景に配置しないでください。InformationPanelをBaseColumnで包むか、InformationPanelを包んでいるDialogのcontentBgColorを"COLUMN"や"OVER_BACKGROUND"にしてください。詳細: https://smarthr.design/products/components/information-panel/',
     },
     schema: [],
   },

--- a/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
+++ b/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
@@ -17,11 +17,6 @@
 module.exports = {
   meta: {
     type: 'suggestion',
-    docs: {
-      description: 'InformationPanelを白背景に配置することを禁止します',
-      category: 'Best Practices',
-      recommended: false,
-    },
     messages: {
       inWhiteBg: 'InformationPanelを白背景に配置しないでください。Stack/Clusterなどレイアウトコンポーネントで包むか、BaseColumnを使用、またはDialog使用時はcontentBgColorを"COLUMN"や"OVER_BACKGROUND"に設定してください。詳細: https://smarthr.design/products/components/information-panel/',
     },

--- a/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
+++ b/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
@@ -18,7 +18,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     messages: {
-      inWhiteBg: 'InformationPanelを白背景に配置しないでください。BaseColumnで包むか、Dialog使用時はcontentBgColorを"COLUMN"や"OVER_BACKGROUND"に設定してください。詳細: https://smarthr.design/products/components/information-panel/',
+      inWhiteBg: 'InformationPanelを白背景に配置しないでください。InformationPanelをBaseColumnで包むか、Dialog使用時はcontentBgColorを"COLUMN"や"OVER_BACKGROUND"に設定してください。詳細: https://smarthr.design/products/components/information-panel/',
     },
     schema: [],
   },

--- a/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
+++ b/packages/eslint-plugin-smarthr/rules/design-system-guideline-prohibit-information-panel-in-white-bg/index.js
@@ -18,7 +18,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     messages: {
-      inWhiteBg: 'InformationPanelを白背景に配置しないでください。InformationPanelをBaseColumnで包むか、InformationPanelを包んでいるDialogのcontentBgColorを"COLUMN"や"OVER_BACKGROUND"にしてください。詳細: https://smarthr.design/products/components/information-panel/',
+      inWhiteBg: 'InformationPanelを白背景に配置しないでください。InformationPanelをBaseColumnで包むか、InformationPanelを包んでいるDialogのcontentBgColorにWHITE以外の値を指定してください。詳細: https://smarthr.design/products/components/information-panel/',
     },
     schema: [],
   },

--- a/packages/eslint-plugin-smarthr/test/design-system-guideline-prohibit-information-panel-in-white-bg.js
+++ b/packages/eslint-plugin-smarthr/test/design-system-guideline-prohibit-information-panel-in-white-bg.js
@@ -1,0 +1,128 @@
+const rule = require('../rules/design-system-guideline-prohibit-information-panel-in-white-bg')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+ruleTester.run('design-system-guideline-prohibit-information-panel-in-white-bg', rule, {
+  valid: [
+    // InformationPanel単体（Base外）
+    {
+      code: '<InformationPanel>情報</InformationPanel>',
+    },
+
+    // Base > BaseColumn > InformationPanel
+    {
+      code: '<Base><BaseColumn><InformationPanel>情報</InformationPanel></BaseColumn></Base>',
+    },
+
+    // Stack内
+    {
+      code: '<Stack><InformationPanel>情報</InformationPanel></Stack>',
+    },
+
+    // Cluster内
+    {
+      code: '<Cluster><InformationPanel>情報</InformationPanel></Cluster>',
+    },
+
+    // Base > BaseColumn > div > InformationPanel
+    {
+      code: '<Base><BaseColumn><div><InformationPanel>情報</InformationPanel></div></BaseColumn></Base>',
+    },
+
+    // ActionDialog with contentBgColor="COLUMN"
+    {
+      code: '<ActionDialog contentBgColor="COLUMN"><InformationPanel>情報</InformationPanel></ActionDialog>',
+    },
+
+    // FormDialog with contentBgColor="OVER_BACKGROUND"
+    {
+      code: '<FormDialog contentBgColor="OVER_BACKGROUND"><InformationPanel>情報</InformationPanel></FormDialog>',
+    },
+
+    // MessageDialog with contentBgColor="COLUMN"
+    {
+      code: '<MessageDialog contentBgColor="COLUMN"><InformationPanel>情報</InformationPanel></MessageDialog>',
+    },
+
+    // StepFormDialog with contentBgColor="OVER_BACKGROUND"
+    {
+      code: '<StepFormDialog contentBgColor="OVER_BACKGROUND"><InformationPanel>情報</InformationPanel></StepFormDialog>',
+    },
+
+    // Dialog > BaseColumn > InformationPanel
+    {
+      code: '<ActionDialog><BaseColumn><InformationPanel>情報</InformationPanel></BaseColumn></ActionDialog>',
+    },
+  ],
+
+  invalid: [
+    // Base直下
+    {
+      code: '<Base><InformationPanel>情報</InformationPanel></Base>',
+      errors: [{ messageId: 'inWhiteBg' }],
+    },
+
+    // Base > div > InformationPanel
+    {
+      code: '<Base><div><InformationPanel>情報</InformationPanel></div></Base>',
+      errors: [{ messageId: 'inWhiteBg' }],
+    },
+
+    // Base > Stack > InformationPanel
+    {
+      code: '<Base><Stack><InformationPanel>情報</InformationPanel></Stack></Base>',
+      errors: [{ messageId: 'inWhiteBg' }],
+    },
+
+    // Base > BaseColumn > Base > InformationPanel
+    {
+      code: '<Base><BaseColumn><Base><InformationPanel>情報</InformationPanel></Base></BaseColumn></Base>',
+      errors: [{ messageId: 'inWhiteBg' }],
+    },
+
+    // ActionDialog（contentBgColor未指定）
+    {
+      code: '<ActionDialog><InformationPanel>情報</InformationPanel></ActionDialog>',
+      errors: [{ messageId: 'inWhiteBg' }],
+    },
+
+    // FormDialog（contentBgColor="WHITE"）
+    {
+      code: '<FormDialog contentBgColor="WHITE"><InformationPanel>情報</InformationPanel></FormDialog>',
+      errors: [{ messageId: 'inWhiteBg' }],
+    },
+
+    // MessageDialog（contentBgColor未指定）
+    {
+      code: '<MessageDialog><InformationPanel>情報</InformationPanel></MessageDialog>',
+      errors: [{ messageId: 'inWhiteBg' }],
+    },
+
+    // StepFormDialog（contentBgColor="WHITE"）
+    {
+      code: '<StepFormDialog contentBgColor="WHITE"><InformationPanel>情報</InformationPanel></StepFormDialog>',
+      errors: [{ messageId: 'inWhiteBg' }],
+    },
+
+    // ActionDialog > div > InformationPanel（contentBgColor未指定）
+    {
+      code: '<ActionDialog><div><InformationPanel>情報</InformationPanel></div></ActionDialog>',
+      errors: [{ messageId: 'inWhiteBg' }],
+    },
+
+    // ネスト: Base > div > Base > InformationPanel
+    {
+      code: '<Base><div><Base><InformationPanel>情報</InformationPanel></Base></div></Base>',
+      errors: [{ messageId: 'inWhiteBg' }],
+    },
+  ],
+})


### PR DESCRIPTION
## Summary
SmartHR Design Systemのガイドラインに基づき、InformationPanelを白背景に直接配置することを防ぐESLintルールを追加しました。

## 追加ルール
`design-system-guideline-prohibit-information-panel-in-white-bg`

## 検出パターン
- Base内にInformationPanel
- Dialog内にInformationPanel（contentBgColorが未指定またはWHITE）

## 例外
- BaseColumn内にある場合（背景色を持つため）
- DialogでcontentBgColorがWHITE以外の場合

## 参考
- https://smarthr.design/products/components/information-panel/#h3-1
- https://github.com/kufu/hanica/pull/58821#discussion_r3255956495

## Test plan
- [x] 単体テスト追加・実行 (20 tests passed)
- [ ] eslint-plugin-smarthrリリース後、eslint-config-smarthr/oxlint-config-smarthrで有効化（別PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)