### PR TITLE
feat: eslint-plugin-smarthrを6.16.0に更新 (eslint-config-smarthr)

### DIFF
--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -72,8 +72,10 @@ export default [
       'smarthr/best-practice-for-text-component': 'warn', // TODO: 2026/04にwarn化。問題なければerrorに変更予定
       'smarthr/best-practice-for-unnesessary-early-return': 'off', // TODO: 2025/12に導入。導入したプロダクトの数に応じてerror化を検討予定
       'smarthr/component-name': 'error',
+      'smarthr/design-system-guideline-bulk-action-row-button': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
       'smarthr/design-system-guideline-prohibit-dialog-button-icon': 'warn', // TODO: 2026/04にwarn化。問題なければerrorに変更予定
       'smarthr/design-system-guideline-prohibit-double-icons': 'off',
+      'smarthr/design-system-guideline-prohibit-information-panel-in-white-bg': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
       'smarthr/format-import-path': 'off',
       'smarthr/format-translate-component': 'off',
       'smarthr/no-import-other-domain': 'off',

--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-smarthr": "6.15.0",
+    "eslint-plugin-smarthr": "6.16.0",
     "globals": "^17.6.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
@@ -3094,11 +3094,17 @@ exports[`should match ESLint Configuration snapshot 1`] = `
     "smarthr/component-name": [
       2,
     ],
+    "smarthr/design-system-guideline-bulk-action-row-button": [
+      1,
+    ],
     "smarthr/design-system-guideline-prohibit-dialog-button-icon": [
       1,
     ],
     "smarthr/design-system-guideline-prohibit-double-icons": [
       0,
+    ],
+    "smarthr/design-system-guideline-prohibit-information-panel-in-white-bg": [
+      1,
     ],
     "smarthr/format-import-path": [
       0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.15.0
-        version: 6.15.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.16.0
+        version: 6.16.0(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -3474,13 +3474,13 @@ packages:
     peerDependencies:
       eslint: ^9
 
-  eslint-plugin-smarthr@6.14.0:
-    resolution: {integrity: sha512-s5UPhg6XT1GRhbKG9xFaPTt1c+JkyFAC3SfNxO5BnrPKUVnXZBQ7qWNXbth5qb3qEAYJm4M+ZExc60MC+uQJzQ==}
+  eslint-plugin-smarthr@6.15.0:
+    resolution: {integrity: sha512-4AgqU7lDd6lOa2DOt4v5P+K96CSLVGyPTMpWNznJ2oiZHhrSoZ6O65vrIxoQGB/OW+81czrKplMTcwR9GoYXGg==}
     peerDependencies:
       eslint: ^9
 
-  eslint-plugin-smarthr@6.15.0:
-    resolution: {integrity: sha512-4AgqU7lDd6lOa2DOt4v5P+K96CSLVGyPTMpWNznJ2oiZHhrSoZ6O65vrIxoQGB/OW+81czrKplMTcwR9GoYXGg==}
+  eslint-plugin-smarthr@6.16.0:
+    resolution: {integrity: sha512-yU+cmtEnogu2ef0AVwu80v8+RQIPDfXNKMGfSWGbuY6qzdVvfxnXLRT5azmpEgwv+nNpz61FBpRq7OvxZo010A==}
     peerDependencies:
       eslint: ^9
 
@@ -9748,12 +9748,12 @@ snapshots:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3
 
-  eslint-plugin-smarthr@6.14.0(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-smarthr@6.15.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3
 
-  eslint-plugin-smarthr@6.15.0(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-smarthr@6.16.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary
- eslint-plugin-smarthrを6.15.0から6.16.0に更新
- v6.16.0で追加された新しいルールを`warn`で設定：
  - `design-system-guideline-bulk-action-row-button`
  - `design-system-guideline-prohibit-information-panel-in-white-bg`

## Test plan
- [x] スナップショットテストを更新して通過確認
- [ ] 実プロダクトでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)