### PR TITLE
feat: eslint-plugin-smarthrを6.16.0に更新 (oxlint-config-smarthr)

### DIFF
--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -234,8 +234,10 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-text-component': 'warn',
     'eslint-plugin-smarthr/best-practice-for-unnesessary-early-return': 'off',
     'eslint-plugin-smarthr/component-name': 'error',
+    'eslint-plugin-smarthr/design-system-guideline-bulk-action-row-button': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
     'eslint-plugin-smarthr/design-system-guideline-prohibit-dialog-button-icon': 'warn',
     'eslint-plugin-smarthr/design-system-guideline-prohibit-double-icons': 'off',
+    'eslint-plugin-smarthr/design-system-guideline-prohibit-information-panel-in-white-bg': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
     'eslint-plugin-smarthr/format-import-path': 'off',
     'eslint-plugin-smarthr/format-translate-component': 'off',
     'eslint-plugin-smarthr/no-import-other-domain': 'off',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,7 +183,7 @@ importers:
     dependencies:
       eslint-plugin-smarthr:
         specifier: '>=6.14.0'
-        version: 6.15.0(eslint@9.39.4(jiti@2.4.2))
+        version: 6.16.0(eslint@9.39.4(jiti@2.4.2))
       oxlint:
         specifier: '>=1.0.0'
         version: 1.59.0
@@ -3474,13 +3474,13 @@ packages:
     peerDependencies:
       eslint: ^9
 
-  eslint-plugin-smarthr@6.14.0:
-    resolution: {integrity: sha512-s5UPhg6XT1GRhbKG9xFaPTt1c+JkyFAC3SfNxO5BnrPKUVnXZBQ7qWNXbth5qb3qEAYJm4M+ZExc60MC+uQJzQ==}
+  eslint-plugin-smarthr@6.15.0:
+    resolution: {integrity: sha512-4AgqU7lDd6lOa2DOt4v5P+K96CSLVGyPTMpWNznJ2oiZHhrSoZ6O65vrIxoQGB/OW+81czrKplMTcwR9GoYXGg==}
     peerDependencies:
       eslint: ^9
 
-  eslint-plugin-smarthr@6.15.0:
-    resolution: {integrity: sha512-4AgqU7lDd6lOa2DOt4v5P+K96CSLVGyPTMpWNznJ2oiZHhrSoZ6O65vrIxoQGB/OW+81czrKplMTcwR9GoYXGg==}
+  eslint-plugin-smarthr@6.16.0:
+    resolution: {integrity: sha512-yU+cmtEnogu2ef0AVwu80v8+RQIPDfXNKMGfSWGbuY6qzdVvfxnXLRT5azmpEgwv+nNpz61FBpRq7OvxZo010A==}
     peerDependencies:
       eslint: ^9
 
@@ -9748,12 +9748,12 @@ snapshots:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3
 
-  eslint-plugin-smarthr@6.14.0(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-smarthr@6.15.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3
 
-  eslint-plugin-smarthr@6.15.0(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-smarthr@6.16.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary
- eslint-plugin-smarthrを6.16.0に更新（pnpm-lock.yaml経由）
- v6.16.0で追加された新しいルールを`warn`で設定：
  - `design-system-guideline-bulk-action-row-button`
  - `design-system-guideline-prohibit-information-panel-in-white-bg`

## Test plan
- [x] oxlint設定ファイルのバリデーション通過確認
- [ ] 実プロダクトでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)