### PR TITLE
fix: oxlint-config-smarthr の eslint-plugin-smarthr への依存を dependencies に移動

### DIFF
--- a/packages/oxlint-config-smarthr/README.md
+++ b/packages/oxlint-config-smarthr/README.md
@@ -8,7 +8,7 @@ React + TypeScript プロジェクトでの利用を想定しています。
 ## インストール
 
 ```sh
-pnpm add --dev oxlint eslint-plugin-smarthr # peerDependencies
+pnpm add --dev oxlint # peerDependencies
 pnpm add --dev oxlint-config-smarthr
 ```
 

--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -28,8 +28,10 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
+  "dependencies": {
+    "eslint-plugin-smarthr": ">=6.14.0"
+  },
   "peerDependencies": {
-    "eslint-plugin-smarthr": ">=6.14.0",
     "oxlint": ">=1.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- `oxlint-config-smarthr` から `eslint-plugin-smarthr` への依存を `peerDependencies` から `dependencies` に移動
-  `oxlint-config-smarthr` の最新バージョンは基本的に `eslint-plugin-smarthr` の最新バージョンに依存するため、バージョンに強い制約を与えて、プロダクト側が確実に正しいバージョンを使えるようにする。

## 背景
- `oxlint-config-smarthr` が新しい `eslint-plugin-smarthr` のルールを参照しているのに、利用側の `eslint-plugin-smarthr` が古いままだと設定読み込み時にエラーになる問題があった
- `peerDependencies` だと利用側のバージョンに依存してしまうため、`dependencies` として常に最新版がインストールされるようにする

## Test plan
- [ ] CI が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)