### PR TITLE
feat: best-practice-for-no-unnecessary-variableルールを追加

### DIFF
--- a/packages/eslint-plugin-smarthr/README.md
+++ b/packages/eslint-plugin-smarthr/README.md
@@ -27,6 +27,7 @@
 - [best-practice-for-default-props](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-default-props)
 - [best-practice-for-interactive-element](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-interactive-element)
 - [best-practice-for-lazy-variable](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-lazy-variable)
+- [best-practice-for-no-unnecessary-variable](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable)
 - [best-practice-for-layouts](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-layouts)
 - [best-practice-for-nested-attributes-array-index](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-nested-attributes-array-index)
 - [best-practice-for-optional-chaining](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-optional-chaining)

--- a/packages/eslint-plugin-smarthr/libs/ast-utils.js
+++ b/packages/eslint-plugin-smarthr/libs/ast-utils.js
@@ -94,6 +94,62 @@ function containsAwait(node) {
   return containsNodeType(node, 'AwaitExpression')
 }
 
+/**
+ * 式の複雑さを計算
+ * 関数呼び出し、プロパティアクセス、演算子などの数をカウント
+ */
+function calculateComplexity(node) {
+  let complexity = 0
+
+  function traverse(n) {
+    if (!n || typeof n !== 'object') return
+
+    switch (n.type) {
+      case 'CallExpression':
+      case 'MemberExpression':
+      case 'BinaryExpression':
+      case 'LogicalExpression':
+      case 'NewExpression':
+        complexity++
+        break
+      case 'ConditionalExpression':
+        complexity += 2
+        break
+    }
+
+    // 再帰的に子ノードを探索
+    for (const key in n) {
+      if (key === 'parent') continue
+      const child = n[key]
+      if (child) {
+        if (Array.isArray(child)) {
+          child.forEach(c => traverse(c))
+        } else if (typeof child === 'object' && child.type) {
+          traverse(child)
+        }
+      }
+    }
+  }
+
+  traverse(node)
+  return complexity
+}
+
+/**
+ * インライン化時に括弧が必要な式タイプかどうかを判定
+ */
+function needsParentheses(node) {
+  const typesNeedingParens = new Set([
+    'NewExpression',
+    'ObjectExpression',
+    'TSAsExpression',
+    'TSNonNullExpression',
+    'TSTypeAssertion',
+    'ConditionalExpression',
+  ])
+  return typesNeedingParens.has(node.type)
+}
+
 module.exports = {
   isFunctionScope,
   isLoopStatement,
@@ -101,4 +157,6 @@ module.exports = {
   containsNode,
   containsNodeType,
   containsAwait,
+  calculateComplexity,
+  needsParentheses,
 }

--- a/packages/eslint-plugin-smarthr/libs/ast-utils.js
+++ b/packages/eslint-plugin-smarthr/libs/ast-utils.js
@@ -111,6 +111,11 @@ function calculateComplexity(node, maxComplexity) {
 
     switch (n.type) {
       case 'CallExpression':
+        // 引数なしの関数呼び出しは複雑さにカウントしない
+        if (n.arguments.length > 0) {
+          complexity++
+        }
+        break
       case 'MemberExpression':
       case 'BinaryExpression':
       case 'LogicalExpression':

--- a/packages/eslint-plugin-smarthr/libs/ast-utils.js
+++ b/packages/eslint-plugin-smarthr/libs/ast-utils.js
@@ -97,11 +97,16 @@ function containsAwait(node) {
 /**
  * 式の複雑さを計算
  * 関数呼び出し、プロパティアクセス、演算子などの数をカウント
+ * @param {object} node - ASTノード
+ * @param {number} [maxComplexity] - 最大複雑さ（この値に達したら計算を中断）
  */
-function calculateComplexity(node) {
+function calculateComplexity(node, maxComplexity) {
   let complexity = 0
 
   function traverse(n) {
+    // 早期終了: maxComplexityに達したら計算を中断
+    if (maxComplexity !== undefined && complexity >= maxComplexity) return
+
     if (!n || typeof n !== 'object') return
 
     switch (n.type) {

--- a/packages/eslint-plugin-smarthr/libs/ast-utils.js
+++ b/packages/eslint-plugin-smarthr/libs/ast-utils.js
@@ -110,9 +110,12 @@ function calculateComplexity(node) {
       case 'BinaryExpression':
       case 'LogicalExpression':
       case 'NewExpression':
+      case 'SpreadElement':
         complexity++
         break
       case 'ConditionalExpression':
+      case 'ObjectExpression':
+      case 'ArrayExpression':
         complexity += 2
         break
     }

--- a/packages/eslint-plugin-smarthr/libs/ast-utils.js
+++ b/packages/eslint-plugin-smarthr/libs/ast-utils.js
@@ -116,6 +116,8 @@ function calculateComplexity(node) {
       case 'ConditionalExpression':
       case 'ObjectExpression':
       case 'ArrayExpression':
+      case 'ArrowFunctionExpression':
+      case 'FunctionExpression':
         complexity += 2
         break
     }

--- a/packages/eslint-plugin-smarthr/libs/ast-utils.js
+++ b/packages/eslint-plugin-smarthr/libs/ast-utils.js
@@ -123,6 +123,7 @@ function calculateComplexity(node, maxComplexity) {
       case 'ArrayExpression':
       case 'ArrowFunctionExpression':
       case 'FunctionExpression':
+      case 'JSXOpeningElement':
         complexity += 2
         break
     }

--- a/packages/eslint-plugin-smarthr/libs/ast-utils.js
+++ b/packages/eslint-plugin-smarthr/libs/ast-utils.js
@@ -116,6 +116,8 @@ function calculateComplexity(node, maxComplexity) {
       case 'LogicalExpression':
       case 'NewExpression':
       case 'SpreadElement':
+      case 'TSAsExpression':
+      case 'TSTypeAssertion':
         complexity++
         break
       case 'ConditionalExpression':

--- a/packages/eslint-plugin-smarthr/libs/ast-utils.js
+++ b/packages/eslint-plugin-smarthr/libs/ast-utils.js
@@ -104,8 +104,8 @@ function calculateComplexity(node, maxComplexity) {
   let complexity = 0
 
   function traverse(n) {
-    // 早期終了: maxComplexityに達したら計算を中断
-    if (maxComplexity !== undefined && complexity >= maxComplexity) return
+    // 早期終了: maxComplexityを超えたら計算を中断
+    if (maxComplexity !== undefined && complexity > maxComplexity) return
 
     if (!n || typeof n !== 'object') return
 
@@ -136,9 +136,13 @@ function calculateComplexity(node, maxComplexity) {
       const child = n[key]
       if (child) {
         if (Array.isArray(child)) {
-          child.forEach(c => traverse(c))
+          for (const c of child) {
+            traverse(c)
+            if (maxComplexity !== undefined && complexity > maxComplexity) return
+          }
         } else if (typeof child === 'object' && child.type) {
           traverse(child)
+          if (maxComplexity !== undefined && complexity > maxComplexity) return
         }
       }
     }

--- a/packages/eslint-plugin-smarthr/libs/ast-utils.js
+++ b/packages/eslint-plugin-smarthr/libs/ast-utils.js
@@ -16,6 +16,15 @@ const LOOP_STATEMENT_TYPES = new Set([
   'DoWhileStatement',
 ])
 
+const NEEDING_PARENS_TYPES = new Set([
+  'NewExpression',
+  'ObjectExpression',
+  'TSAsExpression',
+  'TSNonNullExpression',
+  'TSTypeAssertion',
+  'ConditionalExpression',
+])
+
 /**
  * ノードが関数スコープかどうか判定
  */
@@ -104,10 +113,13 @@ function calculateComplexity(node, maxComplexity) {
   let complexity = 0
 
   function traverse(n) {
-    // 早期終了: maxComplexityを超えたら計算を中断
-    if (maxComplexity !== undefined && complexity > maxComplexity) return
-
-    if (!n || typeof n !== 'object') return
+    if (
+      !n || typeof n !== 'object' ||
+      // maxComplexityを超えたら計算を中断
+      maxComplexity !== undefined && complexity > maxComplexity
+    ) {
+      return
+    }
 
     switch (n.type) {
       case 'CallExpression':
@@ -137,17 +149,19 @@ function calculateComplexity(node, maxComplexity) {
 
     // 再帰的に子ノードを探索
     for (const key in n) {
-      if (key === 'parent') continue
-      const child = n[key]
-      if (child) {
-        if (Array.isArray(child)) {
-          for (const c of child) {
-            traverse(c)
+      if (key !== 'parent') {
+        const child = n[key]
+
+        if (child) {
+          if (Array.isArray(child)) {
+            for (const c of child) {
+              traverse(c)
+              if (maxComplexity !== undefined && complexity > maxComplexity) return
+            }
+          } else if (typeof child === 'object' && child.type) {
+            traverse(child)
             if (maxComplexity !== undefined && complexity > maxComplexity) return
           }
-        } else if (typeof child === 'object' && child.type) {
-          traverse(child)
-          if (maxComplexity !== undefined && complexity > maxComplexity) return
         }
       }
     }
@@ -161,15 +175,7 @@ function calculateComplexity(node, maxComplexity) {
  * インライン化時に括弧が必要な式タイプかどうかを判定
  */
 function needsParentheses(node) {
-  const typesNeedingParens = new Set([
-    'NewExpression',
-    'ObjectExpression',
-    'TSAsExpression',
-    'TSNonNullExpression',
-    'TSTypeAssertion',
-    'ConditionalExpression',
-  ])
-  return typesNeedingParens.has(node.type)
+  return NEEDING_PARENS_TYPES.has(node.type)
 }
 
 module.exports = {

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
@@ -1,0 +1,163 @@
+# smarthr/best-practice-for-no-unnecessary-variable
+
+一度しか使用されない変数を直接使用することを促すルールです。
+
+不要な変数を作らず、値を直接使用することでコードの可読性とパフォーマンスを向上させます。
+
+## なぜ不要な変数を避けるべきか
+
+### 1. 可読性の向上
+
+一度しか使わない変数は、コードを読む際の認知負荷を増やします。
+
+```js
+// 悪い例: 不要な変数が読みやすさを阻害
+const value = obj.property
+return value
+
+// 良い例: 直接使用で意図が明確
+return obj.property
+```
+
+### 2. パフォーマンスの向上
+
+不要な変数宣言とメモリ割り当てを削減します。
+
+## 前提条件
+
+このルールは `best-practice-for-lazy-variable` ルールが適用済みであることを前提としています。
+両ルールを組み合わせることで、最適な変数配置とインライン化を実現します。
+
+## rules
+
+```js
+{
+  rules: {
+    'smarthr/best-practice-for-lazy-variable': 'error',
+    'smarthr/best-practice-for-no-unnecessary-variable': 'error',
+  },
+}
+```
+
+## ❌ Incorrect
+
+```js
+// 一度しか使わない変数
+const x = getValue()
+console.log(x)
+```
+
+```js
+// return文で一度だけ使用
+function foo() {
+  const result = calculateValue()
+  return result
+}
+```
+
+```js
+// 関数の引数で一度だけ使用
+const data = getData()
+process(data)
+```
+
+## ✅ Correct
+
+### インライン化されたパターン
+
+```js
+// 直接使用
+console.log(getValue())
+```
+
+```js
+// return文で直接使用
+function foo() {
+  return calculateValue()
+}
+```
+
+### 除外されるパターン
+
+```js
+// 2回以上使用される変数
+const x = getValue()
+console.log(x)
+return x
+```
+
+```js
+// ループ内で使用される変数
+const x = getValue()
+for (let i = 0; i < 10; i++) {
+  console.log(x)
+}
+```
+
+```js
+// 関数スコープ内で使用される変数
+const x = getValue()
+array.forEach(() => {
+  console.log(x)
+})
+```
+
+```js
+// React Hooks（useXxxで始まる関数）で初期化される変数
+function Component() {
+  const handleClick = useCallback(() => {
+    console.log('clicked')
+  }, [])
+  return handleClick
+}
+```
+
+```js
+// await式を含む変数
+async function fetchData() {
+  const result = await fetchAPI()
+  console.log(result)
+}
+```
+
+```js
+// 関数式は除外（インライン化時に括弧が必要になるため）
+const getTitle = () => {
+  return condition ? 'A' : 'B'
+}
+console.log(getTitle())
+```
+
+```js
+// 分割代入は除外（将来的に対応予定: object, array両方）
+const { name } = user
+console.log(name)
+```
+
+```js
+// 初期化なしの変数
+let x
+if (condition) {
+  x = getValue1()
+} else {
+  x = getValue2()
+}
+console.log(x)
+```
+
+## autofix
+
+このルールは自動修正に対応しています。
+
+```js
+// Before
+const x = getValue()
+console.log(x)
+
+// After
+console.log(getValue())
+```
+
+### フォーマット
+
+自動修正後はprettierやoxfmtなどのフォーマッターによってインデントや改行が整形されます。

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
@@ -221,6 +221,14 @@ console.log(getTitle())
 ```
 
 ```js
+// TaggedTemplateExpression（styled componentなど）
+const StyledDiv = styled.div`
+  color: red;
+`
+console.log(StyledDiv)
+```
+
+```js
 // export宣言された変数は除外（他のファイルから参照される可能性があるため）
 export const API_URL = 'https://example.com/api'
 export type Config = typeof API_URL
@@ -243,9 +251,26 @@ console.log(result)
 ```
 
 ```js
+// var宣言は除外（スコープの扱いが複雑なため）
+var x = getValue()
+console.log(x)
+```
+
+```js
 // 分割代入は除外（将来的に対応予定: object, array両方）
 const { name } = user
 console.log(name)
+```
+
+```js
+// ループの宣言部分で定義される変数（for-in, for-of, for文のinit）
+for (const item of items) {
+  console.log(item)
+}
+
+for (let i = 0; i < 10; i++) {
+  console.log(i)
+}
 ```
 
 ```js
@@ -354,6 +379,20 @@ function getUser() {
 ```
 
 **注意:** 型注釈は複雑度+1として計算されます。
+
+### 複数変数宣言への対応
+
+複数の変数を同時に宣言している場合、対象の変数のみが削除されます。
+
+```js
+// Before
+const x = 1, y = getValue(), z = 3
+console.log(y)
+
+// After
+const x = 1, z = 3
+console.log(getValue())
+```
 
 ### フォーマット
 

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
@@ -58,7 +58,7 @@ return obj.property
 #### 複雑さの計算方法
 
 **複雑さ +1:**
-- 関数呼び出し (`CallExpression`)
+- 関数呼び出し (`CallExpression`) ※引数がある場合のみ
 - プロパティアクセス (`MemberExpression`)
 - 二項演算子 (`BinaryExpression`)
 - 論理演算子 (`LogicalExpression`)
@@ -66,6 +66,9 @@ return obj.property
 - スプレッド構文 (`SpreadElement`)
 - 型アサーション (`TSAsExpression`, `TSTypeAssertion`)
 - 型注釈 (TypeScript: `const x: Type = ...`)
+
+**複雑さ +0:**
+- 引数なし関数呼び出し (`getValue()`, `Date.now()` など)
 
 **複雑さ +2:**
 - 三項演算子 (`ConditionalExpression`)
@@ -80,10 +83,18 @@ return obj.property
 **総合複雑さ = 変数の式の複雑さ + 使用箇所の複雑さ**
 
 ```js
-// 変数の式: obj.method() = 2 (MemberExpression + CallExpression)
+// 変数の式: obj.method() = 1 (MemberExpression) ※引数なしCallExpressionは0
 // 使用箇所: console.log(x) = 2 (MemberExpression + CallExpression)
-// 総合複雑さ: 4
+// 総合複雑さ: 3
 const result = obj.method()
+console.log(result)
+// → maxComplexity: 5 なのでインライン化される
+
+// 引数ありの場合
+// 変数の式: obj.method(arg) = 2 (MemberExpression + CallExpression)
+// 使用箇所: console.log(x) = 2
+// 総合複雑さ: 4
+const result = obj.method(arg)
 console.log(result)
 // → maxComplexity: 5 なのでインライン化される
 ```
@@ -95,17 +106,17 @@ console.log(result)
 ```js
 // return文で単一変数を返す場合
 function foo() {
-  const result = obj.method().another().property  // 複雑さ 3
+  const result = obj.method().another().property  // 複雑さ 3 (MemberExpression x3、引数なしCallExpression x2は0)
   return result  // 使用箇所の複雑さ 0
 }
 // → 総合複雑さ 0 なのでインライン化される
 
 // return文で式を含む場合（特別扱いされない）
 function bar() {
-  const result = obj.method()  // 複雑さ 2
+  const result = obj.method()  // 複雑さ 1 (MemberExpression、引数なしCallExpressionは0)
   return result.property  // 使用箇所の複雑さ 1
 }
-// → 総合複雑さ 3 なのでインライン化される（maxComplexity: 5）
+// → 総合複雑さ 2 なのでインライン化される（maxComplexity: 5）
 ```
 
 ## ❌ Incorrect
@@ -217,7 +228,7 @@ export type Config = typeof API_URL
 
 ```js
 // 複雑な式は除外（デフォルト maxComplexity: 5）
-// 複雑さ 6 (MemberExpression x2 + CallExpression x2 + ArrowFunction x2) + console.log (複雑さ 2) = 8
+// 複雑さ 6 (MemberExpression x2 + CallExpression x1 + ArrowFunction x2 + 引数なしCallExpression x1は0) + console.log (複雑さ 2) = 8
 const result = array.map(() => obj.method())
 console.log(result)
 ```

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
@@ -65,6 +65,7 @@ return obj.property
 - new式 (`NewExpression`)
 - スプレッド構文 (`SpreadElement`)
 - 型アサーション (`TSAsExpression`, `TSTypeAssertion`)
+- 型注釈 (TypeScript: `const x: Type = ...`)
 
 **複雑さ +2:**
 - 三項演算子 (`ConditionalExpression`)
@@ -281,6 +282,34 @@ console.log(obj.property)
 // After
 console.log(({ a: 1, b: 2 }).property)
 ```
+
+### 型注釈の保持（TypeScript）
+
+TypeScriptで型注釈が付いている変数は、インライン化時に`as`型アサーションとして型情報が保持されます。
+
+```ts
+// Before
+const value: string = getValue()
+console.log(value)
+
+// After
+console.log((getValue() as string))
+```
+
+```ts
+// Before
+function getUser() {
+  const user: User | null = fetchUser()
+  return user
+}
+
+// After
+function getUser() {
+  return (fetchUser() as User | null)
+}
+```
+
+**注意:** 型注釈は複雑度+1として計算されます。
 
 ### フォーマット
 

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
@@ -293,6 +293,20 @@ if (!isNothing) allN = false
 if (!(value === 'nothing')) allN = false
 ```
 
+```js
+// ExpressionStatementの先頭で使用される場合、セミコロンを前置
+// Before
+inputs[0].focus()
+const input = inputs[0]
+input.setSelectionRange(0, 0)
+
+// After
+inputs[0].focus()
+;inputs[0].setSelectionRange(0, 0)
+```
+
+**注意:** セミコロンの前置は、前の文とのメソッドチェーンを防ぐために行われます。
+
 ### 型注釈の保持（TypeScript）
 
 TypeScriptで型注釈が付いている変数は、インライン化時に`as`型アサーションとして型情報が保持されます。

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
@@ -39,6 +39,74 @@ return obj.property
 }
 ```
 
+## options
+
+### maxComplexity
+
+式の複雑さの合計が `maxComplexity` を超える場合、インライン化を行いません。
+
+**デフォルト値**: `5`
+
+```js
+{
+  rules: {
+    'smarthr/best-practice-for-no-unnecessary-variable': ['error', { maxComplexity: 5 }],
+  },
+}
+```
+
+#### 複雑さの計算方法
+
+**複雑さ +1:**
+- 関数呼び出し (`CallExpression`)
+- プロパティアクセス (`MemberExpression`)
+- 二項演算子 (`BinaryExpression`)
+- 論理演算子 (`LogicalExpression`)
+- new式 (`NewExpression`)
+- スプレッド構文 (`SpreadElement`)
+- 型アサーション (`TSAsExpression`, `TSTypeAssertion`)
+
+**複雑さ +2:**
+- 三項演算子 (`ConditionalExpression`)
+- オブジェクトリテラル (`ObjectExpression`)
+- 配列リテラル (`ArrayExpression`)
+- アロー関数 (`ArrowFunctionExpression`)
+- 関数式 (`FunctionExpression`)
+- JSX要素 (`JSXOpeningElement`)
+
+#### 複雑さのチェック方法
+
+**総合複雑さ = 変数の式の複雑さ + 使用箇所の複雑さ**
+
+```js
+// 変数の式: obj.method() = 2 (MemberExpression + CallExpression)
+// 使用箇所: console.log(x) = 2 (MemberExpression + CallExpression)
+// 総合複雑さ: 4
+const result = obj.method()
+console.log(result)
+// → maxComplexity: 5 なのでインライン化される
+```
+
+**return文の特別扱い:**
+- `return x` の形式（単一変数を返す場合）のみ、変数の式の複雑さチェックをスキップ
+- 使用箇所の複雑さのみでチェック
+
+```js
+// return文で単一変数を返す場合
+function foo() {
+  const result = obj.method().another().property  // 複雑さ 3
+  return result  // 使用箇所の複雑さ 0
+}
+// → 総合複雑さ 0 なのでインライン化される
+
+// return文で式を含む場合（特別扱いされない）
+function bar() {
+  const result = obj.method()  // 複雑さ 2
+  return result.property  // 使用箇所の複雑さ 1
+}
+// → 総合複雑さ 3 なのでインライン化される（maxComplexity: 5）
+```
+
 ## ❌ Incorrect
 
 ```js
@@ -48,7 +116,7 @@ console.log(x)
 ```
 
 ```js
-// return文で一度だけ使用
+// return文で単一変数を返す
 function foo() {
   const result = calculateValue()
   return result
@@ -59,6 +127,18 @@ function foo() {
 // 関数の引数で一度だけ使用
 const data = getData()
 process(data)
+```
+
+```js
+// 複雑さが低い式（総合複雑さ 4 ≤ maxComplexity: 5）
+const obj = { a: 1, b: 2 }  // ObjectExpression: 2
+console.log(obj)  // console.log: 2
+```
+
+```js
+// JSX要素（総合複雑さ 4 ≤ maxComplexity: 5）
+const element = <div>Hello</div>  // JSXOpeningElement: 2
+render(element)  // render: 1 + CallExpression: 1
 ```
 
 ## ✅ Correct
@@ -121,11 +201,24 @@ async function fetchData() {
 ```
 
 ```js
-// 関数式は除外（インライン化時に括弧が必要になるため）
+// アロー関数・関数式は除外（可読性低下を防ぐため）
 const getTitle = () => {
   return condition ? 'A' : 'B'
 }
 console.log(getTitle())
+```
+
+```js
+// export宣言された変数は除外（他のファイルから参照される可能性があるため）
+export const API_URL = 'https://example.com/api'
+export type Config = typeof API_URL
+```
+
+```js
+// 複雑な式は除外（デフォルト maxComplexity: 5）
+// 複雑さ 6 (MemberExpression x2 + CallExpression x2 + ArrowFunction x2) + console.log (複雑さ 2) = 8
+const result = array.map(() => obj.method())
+console.log(result)
 ```
 
 ```js
@@ -156,6 +249,37 @@ console.log(x)
 
 // After
 console.log(getValue())
+```
+
+### 括弧の追加
+
+一部の式タイプでは、インライン化時に括弧が自動的に追加されます。
+
+```js
+// Before
+const result = condition ? value1 : value2
+doSomething(result)
+
+// After
+doSomething((condition ? value1 : value2))
+```
+
+```js
+// Before
+const input = element as HTMLInputElement
+return input
+
+// After
+return (element as HTMLInputElement)
+```
+
+```js
+// Before
+const obj = { a: 1, b: 2 }
+console.log(obj.property)
+
+// After
+console.log(({ a: 1, b: 2 }).property)
 ```
 
 ### フォーマット

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
@@ -34,7 +34,7 @@ return obj.property
 {
   rules: {
     'smarthr/best-practice-for-lazy-variable': 'error',
-    'smarthr/best-practice-for-no-unnecessary-variable': 'error',
+    'smarthr/best-practice-for-no-unnecessary-variable': ['error', { fix: false }],  // デフォルト: 自動修正無効
   },
 }
 ```
@@ -77,6 +77,39 @@ return obj.property
 - アロー関数 (`ArrowFunctionExpression`)
 - 関数式 (`FunctionExpression`)
 - JSX要素 (`JSXOpeningElement`)
+
+### fix
+
+自動修正を有効にするかどうかを指定します。
+
+**デフォルト値**: `false`
+
+```js
+{
+  rules: {
+    'smarthr/best-practice-for-no-unnecessary-variable': ['error', { fix: true }],
+  },
+}
+```
+
+#### ⚠️ 自動修正の注意点
+
+自動修正を有効にすると、変数宣言が削除され、式が直接インライン化されます。
+
+**副作用を持つ関数の場合、実行順序が変わる可能性があります**:
+
+```js
+// Before（副作用を持つ関数の場合）
+const result = sideEffect1()  // ← 先に実行される
+sideEffect2()
+console.log(result)
+
+// After（自動修正後）
+sideEffect2()  // ← 先に実行される
+console.log(sideEffect1())
+```
+
+このため、デフォルトでは自動修正を無効にしています。自動修正を使う前に、手動で確認することを推奨します。
 
 #### 複雑さのチェック方法
 
@@ -286,7 +319,7 @@ console.log(x)
 
 ## autofix
 
-このルールは自動修正に対応しています。
+このルールは自動修正に対応しています。自動修正を有効にするには `fix: true` オプションを指定してください。
 
 ```js
 // Before

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
@@ -227,6 +227,15 @@ export type Config = typeof API_URL
 ```
 
 ```js
+// UPPER_SNAKE_CASE形式の定数は除外（慣習的な定数命名）
+const NULL = { label: '', value: '' }
+console.log(NULL)
+
+const API_BASE_URL = 'https://example.com'
+fetch(API_BASE_URL)
+```
+
+```js
 // 複雑な式は除外（デフォルト maxComplexity: 5）
 // 複雑さ 6 (MemberExpression x2 + CallExpression x1 + ArrowFunction x2 + 引数なしCallExpression x1は0) + console.log (複雑さ 2) = 8
 const result = array.map(() => obj.method())

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/README.md
@@ -283,6 +283,16 @@ console.log(obj.property)
 console.log(({ a: 1, b: 2 }).property)
 ```
 
+```js
+// 単項演算子で使用される場合も括弧が必要
+// Before
+const isNothing = value === 'nothing'
+if (!isNothing) allN = false
+
+// After
+if (!(value === 'nothing')) allN = false
+```
+
 ### 型注釈の保持（TypeScript）
 
 TypeScriptで型注釈が付いている変数は、インライン化時に`as`型アサーションとして型情報が保持されます。

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -312,12 +312,13 @@ function createInlineFixer(sourceCode, declarationNode, usage, typeAnnotation) {
 
     // 複数declaratorの場合は該当部分のみを削除
     const range = getDeclaratorRemovalRange(declarationNode, variableDeclaration)
-    if (!range) return []
 
-    return [
-      fixer.removeRange(range),
-      fixer.replaceText(usage, initText)
-    ]
+    return range
+      ? [
+          fixer.removeRange(range),
+          fixer.replaceText(usage, initText)
+        ]
+      : []
   }
 }
 
@@ -332,12 +333,10 @@ function isAtStartOfExpressionStatement(usageNode) {
 
   // 親を辿って、ExpressionStatementに到達するまでチェック
   while (parent) {
-    if (parent.type === 'ExpressionStatement') {
-      return parent.expression === current
-    }
-
-    // 親ノードのタイプによって、currentが左端（先頭）にあるかチェック
     switch (parent.type) {
+      case 'ExpressionStatement':
+        return parent.expression === current
+      // ここから下のcaseで親ノードのタイプによって、currentが左端（先頭）にあるかチェック
       case 'MemberExpression':
         // obj.property の場合、objが左端
         if (parent.object !== current) return false
@@ -403,11 +402,10 @@ function analyzeVariable(sourceCode, node, options = {}) {
   const varName = node.id.name
   const { usages, crossedBarrier } = getVariableUsagesInScope(sourceCode, varName, node)
 
-  // バリアを超えている場合は対象外
-  if (crossedBarrier) return null
-
-  // 使用回数が1回のみ
-  if (usages.length !== 1) return null
+  // 以下の条件に該当する場合は対象外
+  if (crossedBarrier || usages.length !== 1) {
+    return null
+  }
 
   const usage = usages[0]
   const typeAnnotation = getTypeAnnotationText(sourceCode, node)

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -35,25 +35,38 @@ function shouldSkipVariableExceptComplexity(node) {
     !node.init ||
     // ループ変数は対象外（for-in, for-of, for文のinit部分）
     (node.parent.parent && isLoopStatement(node.parent.parent)) ||
-    // React Hooks（useXxxで始まる関数）で初期化される変数は対象外
-    (node.init.type === 'CallExpression' && node.init.callee.type === 'Identifier' && node.init.callee.name.startsWith('use')) ||
     // await式を含む変数は対象外（非同期処理の実行タイミングが変わるため）
-    containsAwait(node.init) ||
-    // 関数式は除外（インライン化時に括弧が必要になり、可読性が下がるため）
-    node.init.type === 'ArrowFunctionExpression' ||
-    node.init.type === 'FunctionExpression' ||
-    // TaggedTemplateExpressionは除外（styled componentなど）
-    node.init.type === 'TaggedTemplateExpression'
+    containsAwait(node.init)
   ) {
     return true
+  }
+
+  switch (node.init.type) {
+    case 'CallExpression': {
+      // React Hooks（useXxxで始まる関数）で初期化される変数は対象外
+      if (node.init.callee.type === 'Identifier' && node.init.callee.name.startsWith('use')) {
+        return true
+      }
+
+      break
+    }
+    // 関数式は除外（インライン化時に括弧が必要になり、可読性が下がるため）
+    case 'ArrowFunctionExpression':
+    case 'FunctionExpression':
+    // TaggedTemplateExpressionは除外（styled componentなど）
+    case 'TaggedTemplateExpression':
+      return true
   }
 
   // export宣言された変数は除外（他のファイルから使用される可能性があるため）
   let current = node.parent
   while (current) {
-    if (current.type === 'ExportNamedDeclaration' || current.type === 'ExportDefaultDeclaration') {
-      return true
+    switch (current.type) {
+      case 'ExportNamedDeclaration':
+      case 'ExportDefaultDeclaration':
+        return true
     }
+
     current = current.parent
   }
 
@@ -69,15 +82,15 @@ function calculateUsageComplexity(usageNode, maxComplexity) {
   // 使用箇所が含まれるステートメントを探す
   let current = usageNode.parent
   while (current) {
-    if (
-      current.type === 'ExpressionStatement' ||
-      current.type === 'ReturnStatement' ||
-      current.type === 'IfStatement' ||
-      current.type === 'SwitchStatement' ||
-      current.type === 'VariableDeclaration'
-    ) {
-      return calculateComplexity(current, maxComplexity)
+    switch (current.type) {
+      case 'ExpressionStatement':
+      case 'ReturnStatement':
+      case 'IfStatement':
+      case 'SwitchStatement':
+      case 'VariableDeclaration':
+        return calculateComplexity(current, maxComplexity)
     }
+
     current = current.parent
   }
   return 0
@@ -95,13 +108,14 @@ function isUsedInReturnStatement(usageNode) {
     if (current.type === 'ReturnStatement') {
       // return文の引数が単一の変数（Identifier）である場合のみtrue
       return current.argument && current.argument.type === 'Identifier' && current.argument === usageNode
-    }
-    // 関数スコープを超えたら終了
-    if (isFunctionScope(current)) {
+    } else if (isFunctionScope(current)) {
+      // 関数スコープを超えたら終了
       return false
     }
+
     current = current.parent
   }
+
   return false
 }
 
@@ -131,6 +145,7 @@ function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
     while (current) {
       if (current === declarationNode.init) return true
       if (current === declarationNode) return false
+
       current = current.parent
     }
     return false

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -74,6 +74,22 @@ function shouldSkipVariableExceptComplexity(node) {
 }
 
 /**
+ * 型注釈のテキストを取得
+ * @param {object} sourceCode - SourceCode
+ * @param {object} node - VariableDeclaratorノード
+ * @returns {string|null} 型注釈のテキスト（`: Type`の形式から`Type`部分のみ）
+ */
+function getTypeAnnotationText(sourceCode, node) {
+  if (node.id.typeAnnotation) {
+    const typeAnnotation = node.id.typeAnnotation
+    const typeText = sourceCode.getText(typeAnnotation)
+    // `: Type` の形式から `: ` を除去
+    return typeText.replace(/^:\s*/, '')
+  }
+  return null
+}
+
+/**
  * 使用箇所の複雑さを計算
  * @param {object} usageNode - 使用箇所のノード
  * @param {number} [maxComplexity] - 最大複雑さ（この値に達したら計算を中断）
@@ -207,13 +223,16 @@ function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
 /**
  * インライン化のfixer関数を生成
  */
-function createInlineFixer(sourceCode, declarationNode, usage) {
+function createInlineFixer(sourceCode, declarationNode, usage, typeAnnotation) {
   return function(fixer) {
     const variableDeclaration = declarationNode.parent
     let initText = sourceCode.getText(declarationNode.init)
 
-    // 括弧が必要な式の場合は括弧で囲む
-    if (needsParentheses(declarationNode.init)) {
+    // 型注釈がある場合は as Type を追加
+    if (typeAnnotation) {
+      initText = `(${initText} as ${typeAnnotation})`
+    } else if (needsParentheses(declarationNode.init)) {
+      // 括弧が必要な式の場合は括弧で囲む
       initText = `(${initText})`
     }
 
@@ -287,8 +306,12 @@ function analyzeVariable(sourceCode, node, options = {}) {
     const usage = usages[0]
     const isReturnUsage = isUsedInReturnStatement(usage)
 
+    // 型注釈がある場合は複雑度+1
+    const typeAnnotation = getTypeAnnotationText(sourceCode, node)
+    const typeComplexity = typeAnnotation ? 1 : 0
+
     // return文の場合は、移動元の複雑さチェックをスキップ
-    const sourceComplexity = isReturnUsage ? 0 : calculateComplexity(node.init, maxComplexity + 1)
+    const sourceComplexity = isReturnUsage ? 0 : calculateComplexity(node.init, maxComplexity + 1) + typeComplexity
 
     // sourceComplexityがmaxComplexityを超えている場合は早期終了
     if (sourceComplexity > maxComplexity) {
@@ -309,6 +332,7 @@ function analyzeVariable(sourceCode, node, options = {}) {
       node,
       varName,
       usage,
+      typeAnnotation,
     }
   }
 
@@ -340,7 +364,7 @@ module.exports = {
           node: analysis.node,
           messageId: 'inlineVariable',
           data: { name: analysis.varName },
-          fix: createInlineFixer(sourceCode, analysis.node, analysis.usage),
+          fix: createInlineFixer(sourceCode, analysis.node, analysis.usage, analysis.typeAnnotation),
         })
       },
     }

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -15,7 +15,7 @@ const SCHEMA = [
       maxComplexity: {
         type: 'integer',
         minimum: 0,
-        default: 3,
+        default: 5,
       },
     },
     additionalProperties: false,
@@ -42,24 +42,43 @@ function shouldSkipVariableExceptComplexity(node) {
     // 関数式は除外（インライン化時に括弧が必要になり、可読性が下がるため）
     node.init.type === 'ArrowFunctionExpression' ||
     node.init.type === 'FunctionExpression' ||
-    // オブジェクト/配列式は除外（スプレッド構文が含まれる場合、意味が変わる可能性があるため）
-    node.init.type === 'ObjectExpression' ||
-    node.init.type === 'ArrayExpression' ||
     // TaggedTemplateExpressionは除外（styled componentなど）
     node.init.type === 'TaggedTemplateExpression'
   ) {
     return true
   }
 
+  // export宣言された変数は除外（他のファイルから使用される可能性があるため）
+  let current = node.parent
+  while (current) {
+    if (current.type === 'ExportNamedDeclaration' || current.type === 'ExportDefaultDeclaration') {
+      return true
+    }
+    current = current.parent
+  }
+
   return false
 }
 
 /**
- * 複雑さでスキップすべきかを判定
+ * 使用箇所の複雑さを計算
  */
-function shouldSkipByComplexity(node, maxComplexity) {
-  const complexity = calculateComplexity(node.init)
-  return complexity > maxComplexity
+function calculateUsageComplexity(usageNode) {
+  // 使用箇所が含まれるステートメントを探す
+  let current = usageNode.parent
+  while (current) {
+    if (
+      current.type === 'ExpressionStatement' ||
+      current.type === 'ReturnStatement' ||
+      current.type === 'IfStatement' ||
+      current.type === 'SwitchStatement' ||
+      current.type === 'VariableDeclaration'
+    ) {
+      return calculateComplexity(current)
+    }
+    current = current.parent
+  }
+  return 0
 }
 
 /**
@@ -230,7 +249,7 @@ function createInlineFixer(sourceCode, declarationNode, usage) {
  * 変数が不要な変数化かどうかを判定
  */
 function analyzeVariable(sourceCode, node, options = {}) {
-  const maxComplexity = options.maxComplexity ?? 3
+  const maxComplexity = options.maxComplexity ?? 5
 
   // 複雑さ以外の理由でスキップ
   if (shouldSkipVariableExceptComplexity(node)) return null
@@ -244,9 +263,15 @@ function analyzeVariable(sourceCode, node, options = {}) {
   // 使用回数が1回のみ
   if (usages.length === 1) {
     const usage = usages[0]
+    const isReturnUsage = isUsedInReturnStatement(usage)
 
-    // return文以外で使用されている場合は複雑さチェック適用
-    if (!isUsedInReturnStatement(usage) && shouldSkipByComplexity(node, maxComplexity)) {
+    // return文の場合は、移動元の複雑さチェックをスキップ
+    const sourceComplexity = isReturnUsage ? 0 : calculateComplexity(node.init)
+    const targetComplexity = calculateUsageComplexity(usage)
+    const totalComplexity = sourceComplexity + targetComplexity
+
+    // 合計の複雑さがmaxComplexityを超える場合はスキップ
+    if (totalComplexity > maxComplexity) {
       return null
     }
 

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -258,11 +258,12 @@ function getDeclaratorRemovalRange(declarationNode, variableDeclaration) {
   const declarators = variableDeclaration.declarations
   const index = declarators.indexOf(declarationNode)
 
-  if (index === -1) return null
-
-  // 最初のdeclarator: 次のdeclaratorの前のカンマまで削除
-  if (index === 0) {
-    return [declarationNode.range[0], declarators[1].range[0]]
+  switch (index) {
+    case -1:
+      return null
+    // 最初のdeclarator: 次のdeclaratorの前のカンマまで削除
+    case 0:
+      return [declarationNode.range[0], declarators[1].range[0]]
   }
 
   // 最後以外のdeclarator: カンマを含めて削除

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -180,6 +180,8 @@ function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
   const statements = getStatements(scopeNode)
   const declarationIndex = statements.indexOf(variableDeclaration)
 
+  if (declarationIndex === -1) return { usages: [], crossedBarrier: false }
+
   for (let i = declarationIndex + 1; i < statements.length; i++) {
     traverse(statements[i])
   }

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -84,14 +84,17 @@ function calculateUsageComplexity(usageNode, maxComplexity) {
 }
 
 /**
- * 変数がreturn文で使用されているかを判定
+ * 変数がreturn文で単一の変数として使用されているかを判定
+ * return x → true
+ * return x.property → false
+ * return func(x) → false
  */
 function isUsedInReturnStatement(usageNode) {
   let current = usageNode.parent
   while (current) {
     if (current.type === 'ReturnStatement') {
-      // return文の引数部分であることを確認
-      return current.argument && containsNode(current.argument, usageNode)
+      // return文の引数が単一の変数（Identifier）である場合のみtrue
+      return current.argument && current.argument.type === 'Identifier' && current.argument === usageNode
     }
     // 関数スコープを超えたら終了
     if (isFunctionScope(current)) {

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -239,6 +239,13 @@ function createInlineFixer(sourceCode, declarationNode, usage, typeAnnotation) {
       initText = `(${initText})`
     }
 
+    // 使用箇所がExpressionStatementの先頭にある場合、セミコロンを前置
+    // （前の文とのメソッドチェーンを防ぐため）
+    const isAtStart = isAtStartOfExpressionStatement(usage)
+    if (isAtStart) {
+      initText = `;${initText}`
+    }
+
     // VariableDeclarationに含まれるdeclaratorが1つだけの場合は行全体を削除
     if (variableDeclaration.declarations.length === 1) {
       const text = sourceCode.text
@@ -287,6 +294,53 @@ function createInlineFixer(sourceCode, declarationNode, usage, typeAnnotation) {
       fixer.replaceText(usage, initText)
     ]
   }
+}
+
+/**
+ * 使用箇所がExpressionStatementの式の先頭（左端）にあるかチェック
+ * 例: input.setSelectionRange(0, 0) のinputは先頭
+ *     console.log(x) のxは先頭ではない（consoleが先頭）
+ */
+function isAtStartOfExpressionStatement(usageNode) {
+  let current = usageNode
+  let parent = usageNode.parent
+
+  // 親を辿って、ExpressionStatementに到達するまでチェック
+  while (parent) {
+    if (parent.type === 'ExpressionStatement') {
+      // ExpressionStatementの式が現在のノードである場合、先頭
+      return parent.expression === current
+    }
+
+    // 親ノードのタイプによって、currentが左端（先頭）にあるかチェック
+    if (parent.type === 'MemberExpression') {
+      // obj.property の場合、objが左端
+      if (parent.object !== current) {
+        return false
+      }
+    } else if (parent.type === 'CallExpression') {
+      // func(arg) の場合、funcが左端（argは先頭ではない）
+      if (parent.callee !== current) {
+        return false
+      }
+    } else if (parent.type === 'UnaryExpression') {
+      // !x の場合、xが左端（単項演算子の引数）
+      // これは先頭と見なす
+    } else if (parent.type === 'TSAsExpression' || parent.type === 'TSTypeAssertion') {
+      // (x as Type) の場合、xが左端
+      if (parent.expression !== current) {
+        return false
+      }
+    } else {
+      // それ以外の構造（BinaryExpression、LogicalExpressionなど）
+      // これらは先頭ではない
+      return false
+    }
+
+    current = parent
+    parent = parent.parent
+  }
+  return false
 }
 
 /**

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -62,8 +62,10 @@ function shouldSkipVariableExceptComplexity(node) {
 
 /**
  * 使用箇所の複雑さを計算
+ * @param {object} usageNode - 使用箇所のノード
+ * @param {number} [maxComplexity] - 最大複雑さ（この値に達したら計算を中断）
  */
-function calculateUsageComplexity(usageNode) {
+function calculateUsageComplexity(usageNode, maxComplexity) {
   // 使用箇所が含まれるステートメントを探す
   let current = usageNode.parent
   while (current) {
@@ -74,7 +76,7 @@ function calculateUsageComplexity(usageNode) {
       current.type === 'SwitchStatement' ||
       current.type === 'VariableDeclaration'
     ) {
-      return calculateComplexity(current)
+      return calculateComplexity(current, maxComplexity)
     }
     current = current.parent
   }
@@ -266,8 +268,16 @@ function analyzeVariable(sourceCode, node, options = {}) {
     const isReturnUsage = isUsedInReturnStatement(usage)
 
     // return文の場合は、移動元の複雑さチェックをスキップ
-    const sourceComplexity = isReturnUsage ? 0 : calculateComplexity(node.init)
-    const targetComplexity = calculateUsageComplexity(usage)
+    const sourceComplexity = isReturnUsage ? 0 : calculateComplexity(node.init, maxComplexity + 1)
+
+    // sourceComplexityがmaxComplexityを超えている場合は早期終了
+    if (sourceComplexity > maxComplexity) {
+      return null
+    }
+
+    // 残りの許容複雑さを計算
+    const remainingComplexity = maxComplexity - sourceComplexity + 1
+    const targetComplexity = calculateUsageComplexity(usage, remainingComplexity)
     const totalComplexity = sourceComplexity + targetComplexity
 
     // 合計の複雑さがmaxComplexityを超える場合はスキップ

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -17,6 +17,10 @@ const SCHEMA = [
         minimum: 0,
         default: 5,
       },
+      fix: {
+        type: 'boolean',
+        default: false,
+      },
     },
     additionalProperties: false,
   },
@@ -439,6 +443,7 @@ module.exports = {
   create(context) {
     const sourceCode = context.sourceCode || context.getSourceCode()
     const options = context.options[0] || {}
+    const fix = options.fix
 
     return {
       'VariableDeclarator': (node) => {
@@ -449,7 +454,7 @@ module.exports = {
             node: analysis.node,
             messageId: 'inlineVariable',
             data: { name: analysis.varName },
-            fix: createInlineFixer(sourceCode, analysis.node, analysis.usage, analysis.typeAnnotation),
+            fix: fix ? createInlineFixer(sourceCode, analysis.node, analysis.usage, analysis.typeAnnotation) : null,
           })
         }
       },

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -44,20 +44,12 @@ function shouldSkipVariableExceptComplexity(node) {
     // await式を含む変数は対象外（非同期処理の実行タイミングが変わるため）
     containsAwait(node.init) ||
     // UPPER_SNAKE_CASE形式の定数は除外（慣習的な定数命名）
-    UPPER_SNAKE_CASE_PATTERN.test(node.id.name)
+    UPPER_SNAKE_CASE_PATTERN.test(node.id.name) ||
+    // 関数式、TaggedTemplateExpressionは除外
+    EXCLUDED_INIT_TYPES.includes(node.init.type) ||
+    // React Hooks（useXxxで始まる関数）で初期化される変数は対象外
+    (node.init.type === 'CallExpression' && node.init.callee.type === 'Identifier' && node.init.callee.name.startsWith('use'))
   ) {
-    return true
-  }
-
-  // 関数式、TaggedTemplateExpressionは除外
-  if (EXCLUDED_INIT_TYPES.includes(node.init.type)) {
-    return true
-  }
-
-  // React Hooks（useXxxで始まる関数）で初期化される変数は対象外
-  if (node.init.type === 'CallExpression' &&
-      node.init.callee.type === 'Identifier' &&
-      node.init.callee.name.startsWith('use')) {
     return true
   }
 
@@ -80,13 +72,10 @@ function shouldSkipVariableExceptComplexity(node) {
  * @returns {string|null} 型注釈のテキスト（`: Type`の形式から`Type`部分のみ）
  */
 function getTypeAnnotationText(sourceCode, node) {
-  if (node.id.typeAnnotation) {
-    const typeAnnotation = node.id.typeAnnotation
-    const typeText = sourceCode.getText(typeAnnotation)
+  return node.id.typeAnnotation
     // `: Type` の形式から `: ` を除去
-    return typeText.replace(/^:\s*/, '')
-  }
-  return null
+    ? sourceCode.getText(node.id.typeAnnotation).replace(/^:\s*/, '')
+    : null
 }
 
 /**
@@ -139,7 +128,7 @@ function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
   let scopeNode = variableDeclaration.parent
 
   // BlockStatementまたはProgramまで遡る
-  while (scopeNode && scopeNode.type !== 'Program' && scopeNode.type !== 'BlockStatement') {
+  while (scopeNode && scopeNode.type !== 'BlockStatement' && scopeNode.type !== 'Program') {
     scopeNode = scopeNode.parent
   }
 
@@ -153,11 +142,18 @@ function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
   function isInsideInit(node) {
     let current = node
     while (current) {
-      if (current === declarationNode.init) return true
-      if (current === declarationNode) return false
+      switch (current) {
+        case declarationNode: {
+          return false
+        }
+        case declarationNode.init: {
+          return true
+        }
+      }
 
       current = current.parent
     }
+
     return false
   }
 
@@ -206,13 +202,14 @@ function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
 
     // 子ノードを再帰的に探索
     for (const key in node) {
-      if (key === 'parent') continue
-      const child = node[key]
-      if (child) {
-        if (Array.isArray(child)) {
-          child.forEach(c => traverse(c))
-        } else if (typeof child === 'object' && child.type) {
-          traverse(child)
+      if (key !== 'parent') {
+        const child = node[key]
+        if (child) {
+          if (Array.isArray(child)) {
+            child.forEach(c => traverse(c))
+          } else if (typeof child === 'object' && child.type) {
+            traverse(child)
+          }
         }
       }
     }
@@ -265,13 +262,11 @@ function getDeclaratorRemovalRange(declarationNode, variableDeclaration) {
 
   // 最初のdeclarator: 次のdeclaratorの前のカンマまで削除
   if (index === 0) {
-    const nextDeclarator = declarators[1]
-    return [declarationNode.range[0], nextDeclarator.range[0]]
+    return [declarationNode.range[0], declarators[1].range[0]]
   }
 
   // 最後以外のdeclarator: カンマを含めて削除
-  const prevDeclarator = declarators[index - 1]
-  return [prevDeclarator.range[1], declarationNode.range[1]]
+  return [declarators[index - 1].range[1], declarationNode.range[1]]
 }
 
 /**
@@ -309,9 +304,8 @@ function createInlineFixer(sourceCode, declarationNode, usage, typeAnnotation) {
 
     // 単一declaratorの場合は行全体を削除
     if (variableDeclaration.declarations.length === 1) {
-      const range = getLineRemovalRange(sourceCode, variableDeclaration)
       return [
-        fixer.removeRange(range),
+        fixer.removeRange(getLineRemovalRange(sourceCode, variableDeclaration)),
         fixer.replaceText(usage, initText)
       ]
     }
@@ -450,14 +444,15 @@ module.exports = {
     return {
       'VariableDeclarator': (node) => {
         const analysis = analyzeVariable(sourceCode, node, options)
-        if (!analysis) return
 
-        context.report({
-          node: analysis.node,
-          messageId: 'inlineVariable',
-          data: { name: analysis.varName },
-          fix: createInlineFixer(sourceCode, analysis.node, analysis.usage, analysis.typeAnnotation),
-        })
+        if (analysis) {
+          context.report({
+            node: analysis.node,
+            messageId: 'inlineVariable',
+            data: { name: analysis.varName },
+            fix: createInlineFixer(sourceCode, analysis.node, analysis.usage, analysis.typeAnnotation),
+          })
+        }
       },
     }
   },

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -22,6 +22,12 @@ const SCHEMA = [
   },
 ]
 
+// 定数定義
+const UPPER_SNAKE_CASE_PATTERN = /^[A-Z0-9_]+$/
+const STATEMENT_TYPES = ['ExpressionStatement', 'ReturnStatement', 'IfStatement', 'SwitchStatement', 'VariableDeclaration']
+const EXPORT_TYPES = ['ExportNamedDeclaration', 'ExportDefaultDeclaration']
+const EXCLUDED_INIT_TYPES = ['ArrowFunctionExpression', 'FunctionExpression', 'TaggedTemplateExpression']
+
 /**
  * 複雑さ以外の理由でスキップすべきかを判定
  */
@@ -38,37 +44,29 @@ function shouldSkipVariableExceptComplexity(node) {
     // await式を含む変数は対象外（非同期処理の実行タイミングが変わるため）
     containsAwait(node.init) ||
     // UPPER_SNAKE_CASE形式の定数は除外（慣習的な定数命名）
-    /^[A-Z0-9_]+$/.test(node.id.name)
+    UPPER_SNAKE_CASE_PATTERN.test(node.id.name)
   ) {
     return true
   }
 
-  switch (node.init.type) {
-    case 'CallExpression': {
-      // React Hooks（useXxxで始まる関数）で初期化される変数は対象外
-      if (node.init.callee.type === 'Identifier' && node.init.callee.name.startsWith('use')) {
-        return true
-      }
+  // 関数式、TaggedTemplateExpressionは除外
+  if (EXCLUDED_INIT_TYPES.includes(node.init.type)) {
+    return true
+  }
 
-      break
-    }
-    // 関数式は除外（インライン化時に括弧が必要になり、可読性が下がるため）
-    case 'ArrowFunctionExpression':
-    case 'FunctionExpression':
-    // TaggedTemplateExpressionは除外（styled componentなど）
-    case 'TaggedTemplateExpression':
-      return true
+  // React Hooks（useXxxで始まる関数）で初期化される変数は対象外
+  if (node.init.type === 'CallExpression' &&
+      node.init.callee.type === 'Identifier' &&
+      node.init.callee.name.startsWith('use')) {
+    return true
   }
 
   // export宣言された変数は除外（他のファイルから使用される可能性があるため）
   let current = node.parent
   while (current) {
-    switch (current.type) {
-      case 'ExportNamedDeclaration':
-      case 'ExportDefaultDeclaration':
-        return true
+    if (EXPORT_TYPES.includes(current.type)) {
+      return true
     }
-
     current = current.parent
   }
 
@@ -100,15 +98,9 @@ function calculateUsageComplexity(usageNode, maxComplexity) {
   // 使用箇所が含まれるステートメントを探す
   let current = usageNode.parent
   while (current) {
-    switch (current.type) {
-      case 'ExpressionStatement':
-      case 'ReturnStatement':
-      case 'IfStatement':
-      case 'SwitchStatement':
-      case 'VariableDeclaration':
-        return calculateComplexity(current, maxComplexity)
+    if (STATEMENT_TYPES.includes(current.type)) {
+      return calculateComplexity(current, maxComplexity)
     }
-
     current = current.parent
   }
   return 0
@@ -170,6 +162,26 @@ function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
   }
 
   /**
+   * 変数の使用箇所として収集すべきIdentifierかチェック
+   */
+  function isTargetIdentifier(node) {
+    return node.type === 'Identifier' &&
+           node.name === varName &&
+           node !== declarationNode.id &&
+           !isInsideInit(node)
+  }
+
+  /**
+   * 同名変数の再宣言かチェック
+   */
+  function isRedeclaration(node) {
+    return node.type === 'VariableDeclarator' &&
+           node !== declarationNode &&
+           node.id.type === 'Identifier' &&
+           node.id.name === varName
+  }
+
+  /**
    * 同一スコープ内のみを探索（ループ・関数スコープはバリア）
    */
   function traverse(node) {
@@ -182,16 +194,13 @@ function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
     }
 
     // 変数名が一致するIdentifierを収集（宣言自体と初期化式内は除外）
-    if (node.type === 'Identifier' && node.name === varName && node !== declarationNode.id && !isInsideInit(node)) {
+    if (isTargetIdentifier(node)) {
       usages.push(node)
       return
     }
 
     // 同名変数の再宣言がある場合はその先を探索しない
-    if (node.type === 'VariableDeclarator' &&
-        node !== declarationNode &&
-        node.id.type === 'Identifier' &&
-        node.id.name === varName) {
+    if (isRedeclaration(node)) {
       return
     }
 
@@ -223,76 +232,96 @@ function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
 }
 
 /**
+ * 行全体を削除する範囲を取得
+ */
+function getLineRemovalRange(sourceCode, variableDeclaration) {
+  const text = sourceCode.text
+  const startPos = variableDeclaration.range[0]
+  const endPos = variableDeclaration.range[1]
+
+  let lineStart = startPos
+  while (lineStart > 0 && text[lineStart - 1] !== '\n' && text[lineStart - 1] !== '\r') {
+    lineStart--
+  }
+
+  let removeEnd = endPos
+  if (text[endPos] === '\n') {
+    removeEnd = endPos + 1
+  } else if (text[endPos] === '\r' && text[endPos + 1] === '\n') {
+    removeEnd = endPos + 2
+  }
+
+  return [lineStart, removeEnd]
+}
+
+/**
+ * 複数declaratorから特定のものを削除する範囲を取得
+ */
+function getDeclaratorRemovalRange(declarationNode, variableDeclaration) {
+  const declarators = variableDeclaration.declarations
+  const index = declarators.indexOf(declarationNode)
+
+  if (index === -1) return null
+
+  // 最初のdeclarator: 次のdeclaratorの前のカンマまで削除
+  if (index === 0) {
+    const nextDeclarator = declarators[1]
+    return [declarationNode.range[0], nextDeclarator.range[0]]
+  }
+
+  // 最後以外のdeclarator: カンマを含めて削除
+  const prevDeclarator = declarators[index - 1]
+  return [prevDeclarator.range[1], declarationNode.range[1]]
+}
+
+/**
+ * インライン化用のテキストを準備
+ */
+function prepareInlineText(sourceCode, declarationNode, usage, typeAnnotation) {
+  let initText = sourceCode.getText(declarationNode.init)
+
+  // 使用箇所が単項演算子の引数の場合は括弧が必要
+  const usageNeedsParentheses = usage.parent && usage.parent.type === 'UnaryExpression' && usage.parent.argument === usage
+
+  // 型注釈がある場合は as Type を追加
+  if (typeAnnotation) {
+    initText = `(${initText} as ${typeAnnotation})`
+  } else if (needsParentheses(declarationNode.init) || usageNeedsParentheses) {
+    // 括弧が必要な式の場合は括弧で囲む
+    initText = `(${initText})`
+  }
+
+  // 使用箇所がExpressionStatementの先頭にある場合、セミコロンを前置
+  if (isAtStartOfExpressionStatement(usage)) {
+    initText = `;${initText}`
+  }
+
+  return initText
+}
+
+/**
  * インライン化のfixer関数を生成
  */
 function createInlineFixer(sourceCode, declarationNode, usage, typeAnnotation) {
   return function(fixer) {
     const variableDeclaration = declarationNode.parent
-    let initText = sourceCode.getText(declarationNode.init)
+    const initText = prepareInlineText(sourceCode, declarationNode, usage, typeAnnotation)
 
-    // 使用箇所が単項演算子の引数の場合は括弧が必要
-    const usageNeedsParentheses = usage.parent && usage.parent.type === 'UnaryExpression' && usage.parent.argument === usage
-
-    // 型注釈がある場合は as Type を追加
-    if (typeAnnotation) {
-      initText = `(${initText} as ${typeAnnotation})`
-    } else if (needsParentheses(declarationNode.init) || usageNeedsParentheses) {
-      // 括弧が必要な式の場合は括弧で囲む
-      initText = `(${initText})`
-    }
-
-    // 使用箇所がExpressionStatementの先頭にある場合、セミコロンを前置
-    // （前の文とのメソッドチェーンを防ぐため）
-    const isAtStart = isAtStartOfExpressionStatement(usage)
-    if (isAtStart) {
-      initText = `;${initText}`
-    }
-
-    // VariableDeclarationに含まれるdeclaratorが1つだけの場合は行全体を削除
+    // 単一declaratorの場合は行全体を削除
     if (variableDeclaration.declarations.length === 1) {
-      const text = sourceCode.text
-      const startPos = variableDeclaration.range[0]
-      const endPos = variableDeclaration.range[1]
-
-      let lineStart = startPos
-      while (lineStart > 0 && text[lineStart - 1] !== '\n' && text[lineStart - 1] !== '\r') {
-        lineStart--
-      }
-
-      let removeEnd = endPos
-      if (text[endPos] === '\n') {
-        removeEnd = endPos + 1
-      } else if (text[endPos] === '\r' && text[endPos + 1] === '\n') {
-        removeEnd = endPos + 2
-      }
-
+      const range = getLineRemovalRange(sourceCode, variableDeclaration)
       return [
-        fixer.removeRange([lineStart, removeEnd]),
+        fixer.removeRange(range),
         fixer.replaceText(usage, initText)
       ]
     }
 
-    // 複数のdeclaratorがある場合は、このdeclaratorのみを削除
-    // const x = 1, y = 2 のようなケース
-    const declarators = variableDeclaration.declarations
-    const index = declarators.indexOf(declarationNode)
+    // 複数declaratorの場合は該当部分のみを削除
+    const range = getDeclaratorRemovalRange(declarationNode, variableDeclaration)
+    if (!range) return []
 
-    if (index === -1) return []
-
-    // 最初のdeclarator
-    if (index === 0) {
-      // 次のdeclaratorの前のカンマまで削除
-      const nextDeclarator = declarators[1]
-      return [
-        fixer.removeRange([declarationNode.range[0], nextDeclarator.range[0]]),
-        fixer.replaceText(usage, initText)
-      ]
-    }
-
-    // 最後以外のdeclarator: カンマを含めて削除
-    const prevDeclarator = declarators[index - 1]
     return [
-      fixer.removeRange([prevDeclarator.range[1], declarationNode.range[1]]),
+      fixer.removeRange(range),
       fixer.replaceText(usage, initText)
     ]
   }
@@ -310,39 +339,62 @@ function isAtStartOfExpressionStatement(usageNode) {
   // 親を辿って、ExpressionStatementに到達するまでチェック
   while (parent) {
     if (parent.type === 'ExpressionStatement') {
-      // ExpressionStatementの式が現在のノードである場合、先頭
       return parent.expression === current
     }
 
     // 親ノードのタイプによって、currentが左端（先頭）にあるかチェック
-    if (parent.type === 'MemberExpression') {
-      // obj.property の場合、objが左端
-      if (parent.object !== current) {
+    switch (parent.type) {
+      case 'MemberExpression':
+        // obj.property の場合、objが左端
+        if (parent.object !== current) return false
+        break
+      case 'CallExpression':
+        // func(arg) の場合、funcが左端（argは先頭ではない）
+        if (parent.callee !== current) return false
+        break
+      case 'UnaryExpression':
+        // !x の場合、xが左端（単項演算子の引数）
+        // これは先頭と見なす
+        break
+      case 'TSAsExpression':
+      case 'TSTypeAssertion':
+        // (x as Type) の場合、xが左端
+        if (parent.expression !== current) return false
+        break
+      default:
+        // それ以外の構造（BinaryExpression、LogicalExpressionなど）
+        // これらは先頭ではない
         return false
-      }
-    } else if (parent.type === 'CallExpression') {
-      // func(arg) の場合、funcが左端（argは先頭ではない）
-      if (parent.callee !== current) {
-        return false
-      }
-    } else if (parent.type === 'UnaryExpression') {
-      // !x の場合、xが左端（単項演算子の引数）
-      // これは先頭と見なす
-    } else if (parent.type === 'TSAsExpression' || parent.type === 'TSTypeAssertion') {
-      // (x as Type) の場合、xが左端
-      if (parent.expression !== current) {
-        return false
-      }
-    } else {
-      // それ以外の構造（BinaryExpression、LogicalExpressionなど）
-      // これらは先頭ではない
-      return false
     }
 
     current = parent
     parent = parent.parent
   }
   return false
+}
+
+/**
+ * 複雑さをチェックしてインライン化可能かを判定
+ */
+function checkComplexity(sourceCode, node, usage, typeAnnotation, maxComplexity) {
+  const isReturnUsage = isUsedInReturnStatement(usage)
+  const typeComplexity = typeAnnotation ? 1 : 0
+
+  // return文の場合は、移動元の複雑さチェックをスキップ
+  const sourceComplexity = isReturnUsage ? 0 : calculateComplexity(node.init, maxComplexity + 1) + typeComplexity
+
+  // sourceComplexityがmaxComplexityを超えている場合は早期終了
+  if (sourceComplexity > maxComplexity) {
+    return false
+  }
+
+  // 残りの許容複雑さを計算
+  const remainingComplexity = maxComplexity - sourceComplexity + 1
+  const targetComplexity = calculateUsageComplexity(usage, remainingComplexity)
+  const totalComplexity = sourceComplexity + targetComplexity
+
+  // 合計の複雑さがmaxComplexityを超える場合はスキップ
+  return totalComplexity <= maxComplexity
 }
 
 /**
@@ -361,41 +413,22 @@ function analyzeVariable(sourceCode, node, options = {}) {
   if (crossedBarrier) return null
 
   // 使用回数が1回のみ
-  if (usages.length === 1) {
-    const usage = usages[0]
-    const isReturnUsage = isUsedInReturnStatement(usage)
+  if (usages.length !== 1) return null
 
-    // 型注釈がある場合は複雑度+1
-    const typeAnnotation = getTypeAnnotationText(sourceCode, node)
-    const typeComplexity = typeAnnotation ? 1 : 0
+  const usage = usages[0]
+  const typeAnnotation = getTypeAnnotationText(sourceCode, node)
 
-    // return文の場合は、移動元の複雑さチェックをスキップ
-    const sourceComplexity = isReturnUsage ? 0 : calculateComplexity(node.init, maxComplexity + 1) + typeComplexity
-
-    // sourceComplexityがmaxComplexityを超えている場合は早期終了
-    if (sourceComplexity > maxComplexity) {
-      return null
-    }
-
-    // 残りの許容複雑さを計算
-    const remainingComplexity = maxComplexity - sourceComplexity + 1
-    const targetComplexity = calculateUsageComplexity(usage, remainingComplexity)
-    const totalComplexity = sourceComplexity + targetComplexity
-
-    // 合計の複雑さがmaxComplexityを超える場合はスキップ
-    if (totalComplexity > maxComplexity) {
-      return null
-    }
-
-    return {
-      node,
-      varName,
-      usage,
-      typeAnnotation,
-    }
+  // 複雑さチェック
+  if (!checkComplexity(sourceCode, node, usage, typeAnnotation, maxComplexity)) {
+    return null
   }
 
-  return null
+  return {
+    node,
+    varName,
+    usage,
+    typeAnnotation,
+  }
 }
 
 /**

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -1,0 +1,294 @@
+const {
+  isFunctionScope,
+  isLoopStatement,
+  getStatements,
+  containsAwait,
+  containsNode,
+  calculateComplexity,
+  needsParentheses,
+} = require('../../libs/ast-utils')
+
+const SCHEMA = [
+  {
+    type: 'object',
+    properties: {
+      maxComplexity: {
+        type: 'integer',
+        minimum: 0,
+        default: 3,
+      },
+    },
+    additionalProperties: false,
+  },
+]
+
+/**
+ * 複雑さ以外の理由でスキップすべきかを判定
+ */
+function shouldSkipVariableExceptComplexity(node) {
+  if (
+    // const/let のみ対象（varは除外）
+    node.parent.kind === 'var' ||
+    // 分割代入は除外（将来的に対応予定: ArrayPattern, ObjectPattern）
+    node.id.type !== 'Identifier' ||
+    // 初期化なしは除外
+    !node.init ||
+    // ループ変数は対象外（for-in, for-of, for文のinit部分）
+    (node.parent.parent && isLoopStatement(node.parent.parent)) ||
+    // React Hooks（useXxxで始まる関数）で初期化される変数は対象外
+    (node.init.type === 'CallExpression' && node.init.callee.type === 'Identifier' && node.init.callee.name.startsWith('use')) ||
+    // await式を含む変数は対象外（非同期処理の実行タイミングが変わるため）
+    containsAwait(node.init) ||
+    // 関数式は除外（インライン化時に括弧が必要になり、可読性が下がるため）
+    node.init.type === 'ArrowFunctionExpression' ||
+    node.init.type === 'FunctionExpression' ||
+    // オブジェクト/配列式は除外（スプレッド構文が含まれる場合、意味が変わる可能性があるため）
+    node.init.type === 'ObjectExpression' ||
+    node.init.type === 'ArrayExpression' ||
+    // TaggedTemplateExpressionは除外（styled componentなど）
+    node.init.type === 'TaggedTemplateExpression'
+  ) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * 複雑さでスキップすべきかを判定
+ */
+function shouldSkipByComplexity(node, maxComplexity) {
+  const complexity = calculateComplexity(node.init)
+  return complexity > maxComplexity
+}
+
+/**
+ * 変数がreturn文で使用されているかを判定
+ */
+function isUsedInReturnStatement(usageNode) {
+  let current = usageNode.parent
+  while (current) {
+    if (current.type === 'ReturnStatement') {
+      // return文の引数部分であることを確認
+      return current.argument && containsNode(current.argument, usageNode)
+    }
+    // 関数スコープを超えたら終了
+    if (isFunctionScope(current)) {
+      return false
+    }
+    current = current.parent
+  }
+  return false
+}
+
+/**
+ * 同一スコープ内で変数が使用される回数をカウント
+ * ループ内、関数スコープ内で使用される場合はバリアとして除外
+ */
+function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
+  const usages = []
+  const variableDeclaration = declarationNode.parent
+  let scopeNode = variableDeclaration.parent
+
+  // BlockStatementまたはProgramまで遡る
+  while (scopeNode && scopeNode.type !== 'Program' && scopeNode.type !== 'BlockStatement') {
+    scopeNode = scopeNode.parent
+  }
+
+  if (!scopeNode) return { usages: [], crossedBarrier: false }
+
+  let crossedBarrier = false
+
+  /**
+   * ノードが宣言の初期化式の中にあるかチェック
+   */
+  function isInsideInit(node) {
+    let current = node
+    while (current) {
+      if (current === declarationNode.init) return true
+      if (current === declarationNode) return false
+      current = current.parent
+    }
+    return false
+  }
+
+  /**
+   * 同一スコープ内のみを探索（ループ・関数スコープはバリア）
+   */
+  function traverse(node) {
+    if (!node || typeof node !== 'object') return
+
+    // バリアを検出
+    if (isFunctionScope(node) || isLoopStatement(node)) {
+      crossedBarrier = true
+      return
+    }
+
+    // 変数名が一致するIdentifierを収集（宣言自体と初期化式内は除外）
+    if (node.type === 'Identifier' && node.name === varName && node !== declarationNode.id && !isInsideInit(node)) {
+      usages.push(node)
+      return
+    }
+
+    // 同名変数の再宣言がある場合はその先を探索しない
+    if (node.type === 'VariableDeclarator' &&
+        node !== declarationNode &&
+        node.id.type === 'Identifier' &&
+        node.id.name === varName) {
+      return
+    }
+
+    // 子ノードを再帰的に探索
+    for (const key in node) {
+      if (key === 'parent') continue
+      const child = node[key]
+      if (child) {
+        if (Array.isArray(child)) {
+          child.forEach(c => traverse(c))
+        } else if (typeof child === 'object' && child.type) {
+          traverse(child)
+        }
+      }
+    }
+  }
+
+  // 宣言以降のノードのみを探索
+  const statements = getStatements(scopeNode)
+  const declarationIndex = statements.indexOf(variableDeclaration)
+
+  for (let i = declarationIndex + 1; i < statements.length; i++) {
+    traverse(statements[i])
+  }
+
+  return { usages, crossedBarrier }
+}
+
+/**
+ * インライン化のfixer関数を生成
+ */
+function createInlineFixer(sourceCode, declarationNode, usage) {
+  return function(fixer) {
+    const variableDeclaration = declarationNode.parent
+    let initText = sourceCode.getText(declarationNode.init)
+
+    // 括弧が必要な式の場合は括弧で囲む
+    if (needsParentheses(declarationNode.init)) {
+      initText = `(${initText})`
+    }
+
+    // VariableDeclarationに含まれるdeclaratorが1つだけの場合は行全体を削除
+    if (variableDeclaration.declarations.length === 1) {
+      const text = sourceCode.text
+      const startPos = variableDeclaration.range[0]
+      const endPos = variableDeclaration.range[1]
+
+      let lineStart = startPos
+      while (lineStart > 0 && text[lineStart - 1] !== '\n' && text[lineStart - 1] !== '\r') {
+        lineStart--
+      }
+
+      let removeEnd = endPos
+      if (text[endPos] === '\n') {
+        removeEnd = endPos + 1
+      } else if (text[endPos] === '\r' && text[endPos + 1] === '\n') {
+        removeEnd = endPos + 2
+      }
+
+      return [
+        fixer.removeRange([lineStart, removeEnd]),
+        fixer.replaceText(usage, initText)
+      ]
+    }
+
+    // 複数のdeclaratorがある場合は、このdeclaratorのみを削除
+    // const x = 1, y = 2 のようなケース
+    const declarators = variableDeclaration.declarations
+    const index = declarators.indexOf(declarationNode)
+
+    if (index === -1) return []
+
+    // 最初のdeclarator
+    if (index === 0) {
+      // 次のdeclaratorの前のカンマまで削除
+      const nextDeclarator = declarators[1]
+      return [
+        fixer.removeRange([declarationNode.range[0], nextDeclarator.range[0]]),
+        fixer.replaceText(usage, initText)
+      ]
+    }
+
+    // 最後以外のdeclarator: カンマを含めて削除
+    const prevDeclarator = declarators[index - 1]
+    return [
+      fixer.removeRange([prevDeclarator.range[1], declarationNode.range[1]]),
+      fixer.replaceText(usage, initText)
+    ]
+  }
+}
+
+/**
+ * 変数が不要な変数化かどうかを判定
+ */
+function analyzeVariable(sourceCode, node, options = {}) {
+  const maxComplexity = options.maxComplexity ?? 3
+
+  // 複雑さ以外の理由でスキップ
+  if (shouldSkipVariableExceptComplexity(node)) return null
+
+  const varName = node.id.name
+  const { usages, crossedBarrier } = getVariableUsagesInScope(sourceCode, varName, node)
+
+  // バリアを超えている場合は対象外
+  if (crossedBarrier) return null
+
+  // 使用回数が1回のみ
+  if (usages.length === 1) {
+    const usage = usages[0]
+
+    // return文以外で使用されている場合は複雑さチェック適用
+    if (!isUsedInReturnStatement(usage) && shouldSkipByComplexity(node, maxComplexity)) {
+      return null
+    }
+
+    return {
+      node,
+      varName,
+      usage,
+    }
+  }
+
+  return null
+}
+
+/**
+ * @type {import('@typescript-eslint/utils').TSESLint.RuleModule<''>}
+ */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    schema: SCHEMA,
+    messages: {
+      inlineVariable: '変数"{{name}}"は一度しか使用されていません。直接使用してください。',
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode()
+    const options = context.options[0] || {}
+
+    return {
+      'VariableDeclarator': (node) => {
+        const analysis = analyzeVariable(sourceCode, node, options)
+        if (!analysis) return
+
+        context.report({
+          node: analysis.node,
+          messageId: 'inlineVariable',
+          data: { name: analysis.varName },
+          fix: createInlineFixer(sourceCode, analysis.node, analysis.usage),
+        })
+      },
+    }
+  },
+}
+module.exports.schema = SCHEMA

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -228,10 +228,13 @@ function createInlineFixer(sourceCode, declarationNode, usage, typeAnnotation) {
     const variableDeclaration = declarationNode.parent
     let initText = sourceCode.getText(declarationNode.init)
 
+    // 使用箇所が単項演算子の引数の場合は括弧が必要
+    const usageNeedsParentheses = usage.parent && usage.parent.type === 'UnaryExpression' && usage.parent.argument === usage
+
     // 型注釈がある場合は as Type を追加
     if (typeAnnotation) {
       initText = `(${initText} as ${typeAnnotation})`
-    } else if (needsParentheses(declarationNode.init)) {
+    } else if (needsParentheses(declarationNode.init) || usageNeedsParentheses) {
       // 括弧が必要な式の場合は括弧で囲む
       initText = `(${initText})`
     }

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -36,7 +36,9 @@ function shouldSkipVariableExceptComplexity(node) {
     // ループ変数は対象外（for-in, for-of, for文のinit部分）
     (node.parent.parent && isLoopStatement(node.parent.parent)) ||
     // await式を含む変数は対象外（非同期処理の実行タイミングが変わるため）
-    containsAwait(node.init)
+    containsAwait(node.init) ||
+    // UPPER_SNAKE_CASE形式の定数は除外（慣習的な定数命名）
+    /^[A-Z0-9_]+$/.test(node.id.name)
   ) {
     return true
   }

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -300,13 +300,12 @@ function prepareInlineText(sourceCode, declarationNode, usage, typeAnnotation) {
 function createInlineFixer(sourceCode, declarationNode, usage, typeAnnotation) {
   return function(fixer) {
     const variableDeclaration = declarationNode.parent
-    const initText = prepareInlineText(sourceCode, declarationNode, usage, typeAnnotation)
 
     // 単一declaratorの場合は行全体を削除
     if (variableDeclaration.declarations.length === 1) {
       return [
         fixer.removeRange(getLineRemovalRange(sourceCode, variableDeclaration)),
-        fixer.replaceText(usage, initText)
+        fixer.replaceText(usage, prepareInlineText(sourceCode, declarationNode, usage, typeAnnotation))
       ]
     }
 
@@ -316,7 +315,7 @@ function createInlineFixer(sourceCode, declarationNode, usage, typeAnnotation) {
     return range
       ? [
           fixer.removeRange(range),
-          fixer.replaceText(usage, initText)
+          fixer.replaceText(usage, prepareInlineText(sourceCode, declarationNode, usage, typeAnnotation))
         ]
       : []
   }

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -275,13 +275,14 @@ function getDeclaratorRemovalRange(declarationNode, variableDeclaration) {
 function prepareInlineText(sourceCode, declarationNode, usage, typeAnnotation) {
   let initText = sourceCode.getText(declarationNode.init)
 
-  // 使用箇所が単項演算子の引数の場合は括弧が必要
-  const usageNeedsParentheses = usage.parent && usage.parent.type === 'UnaryExpression' && usage.parent.argument === usage
-
   // 型注釈がある場合は as Type を追加
   if (typeAnnotation) {
     initText = `(${initText} as ${typeAnnotation})`
-  } else if (needsParentheses(declarationNode.init) || usageNeedsParentheses) {
+  } else if (
+    needsParentheses(declarationNode.init) ||
+    // 使用箇所が単項演算子の引数の場合は括弧が必要
+    usage.parent && usage.parent.type === 'UnaryExpression' && usage.parent.argument === usage
+  ) {
     // 括弧が必要な式の場合は括弧で囲む
     initText = `(${initText})`
   }

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable-ts.test.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable-ts.test.js
@@ -60,6 +60,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
           return (element as HTMLInputElement)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -80,6 +81,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
           return (element.value as string)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -100,6 +102,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
           return (getStringValue() as string)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -116,6 +119,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
       output: `
         console.log((123 as number))
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -132,6 +136,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
       output: `
         console.log((getUser() as User | null))
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -148,6 +153,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
       output: `
         console.log((obj.property as string))
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -166,6 +172,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
         doSomething()
         ;(getValue() as string).toUpperCase()
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -184,6 +191,55 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
         inputs[0].focus()
         ;(inputs[0] as HTMLInputElement).setSelectionRange(0, 0)
       `,
+      options: [{ fix: true }],
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'input' },
+        },
+      ],
+    },
+    // fix: false - 型注釈付き変数で自動修正なし
+    {
+      code: `
+        const value: string = getValue()
+        console.log(value)
+      `,
+      options: [{ fix: false }],
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // fix: true - 型注釈付き変数で自動修正あり
+    {
+      code: `
+        const value: string = getValue()
+        console.log(value)
+      `,
+      output: `
+        console.log((getValue() as string))
+      `,
+      options: [{ fix: true }],
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // fix: true - TSAsExpressionで自動修正あり
+    {
+      code: `
+        const input = element as HTMLInputElement
+        return input
+      `,
+      output: `
+        return (element as HTMLInputElement)
+      `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable-ts.test.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable-ts.test.js
@@ -1,0 +1,75 @@
+const rule = require('../rules/best-practice-for-no-unnecessary-variable')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+  },
+})
+
+ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
+  valid: [
+    // TSAsExpression（Complexity 1）+ console.log（Complexity 2）= 3、maxComplexity: 2で除外
+    {
+      code: `
+        const input = element as HTMLInputElement
+        console.log(input)
+      `,
+      options: [{ maxComplexity: 2 }],
+    },
+    // TSAsExpression with MemberExpression（Complexity 2）+ console.log（Complexity 2）= 4、maxComplexity: 3で除外
+    {
+      code: `
+        const input = element.value as string
+        console.log(input)
+      `,
+      options: [{ maxComplexity: 3 }],
+    },
+  ],
+  invalid: [
+    // TSAsExpression（Complexity 1）をreturn文で使用（括弧が必要）
+    {
+      code: `
+        function getInput() {
+          const input = element as HTMLInputElement
+          return input
+        }
+      `,
+      output: `
+        function getInput() {
+          return (element as HTMLInputElement)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'input' },
+        },
+      ],
+    },
+    // TSAsExpression with MemberExpression（Complexity 2）をreturn文で使用（括弧が必要）
+    {
+      code: `
+        function getValue() {
+          const value = element.value as string
+          return value
+        }
+      `,
+      output: `
+        function getValue() {
+          return (element.value as string)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable-ts.test.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable-ts.test.js
@@ -29,13 +29,13 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
       `,
       options: [{ maxComplexity: 3 }],
     },
-    // 型注釈（Complexity 1）+ CallExpression（Complexity 1）+ console.log（Complexity 2）= 4、maxComplexity: 3で除外
+    // 型注釈（Complexity 1）+ CallExpression（引数なしComplexity 0）+ console.log（Complexity 2）= 3、maxComplexity: 2で除外
     {
       code: `
         const value: string = getValue()
         console.log(value)
       `,
-      options: [{ maxComplexity: 3 }],
+      options: [{ maxComplexity: 2 }],
     },
     // 型注釈（Complexity 1）+ MemberExpression（Complexity 1）+ console.log（Complexity 2）= 4、maxComplexity: 3で除外
     {

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable-ts.test.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable-ts.test.js
@@ -29,6 +29,22 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
       `,
       options: [{ maxComplexity: 3 }],
     },
+    // 型注釈（Complexity 1）+ CallExpression（Complexity 1）+ console.log（Complexity 2）= 4、maxComplexity: 3で除外
+    {
+      code: `
+        const value: string = getValue()
+        console.log(value)
+      `,
+      options: [{ maxComplexity: 3 }],
+    },
+    // 型注釈（Complexity 1）+ MemberExpression（Complexity 1）+ console.log（Complexity 2）= 4、maxComplexity: 3で除外
+    {
+      code: `
+        const value: number = obj.property
+        console.log(value)
+      `,
+      options: [{ maxComplexity: 3 }],
+    },
   ],
   invalid: [
     // TSAsExpression（Complexity 1）をreturn文で使用（括弧が必要）
@@ -63,6 +79,74 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
         function getValue() {
           return (element.value as string)
         }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // 型注釈付き変数をreturn文で使用（型注釈をasで保持）
+    {
+      code: `
+        function getValue() {
+          const value: string = getStringValue()
+          return value
+        }
+      `,
+      output: `
+        function getValue() {
+          return (getStringValue() as string)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // 型注釈付き変数を通常の文で使用（型注釈をasで保持）
+    {
+      code: `
+        const value: number = 123
+        console.log(value)
+      `,
+      output: `
+        console.log((123 as number))
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // 型注釈付き変数（複雑な型）
+    {
+      code: `
+        const user: User | null = getUser()
+        console.log(user)
+      `,
+      output: `
+        console.log((getUser() as User | null))
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'user' },
+        },
+      ],
+    },
+    // 型注釈（Complexity 1）+ MemberExpression（Complexity 1）= 2、maxComplexity: 5なのでインライン化
+    {
+      code: `
+        const value: string = obj.property
+        console.log(value)
+      `,
+      output: `
+        console.log((obj.property as string))
       `,
       errors: [
         {

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable-ts.test.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable-ts.test.js
@@ -155,5 +155,41 @@ ruleTester.run('best-practice-for-no-unnecessary-variable (TypeScript)', rule, {
         },
       ],
     },
+    // 型注釈付き変数がExpressionStatementの先頭で使用される場合、セミコロンを前置
+    {
+      code: `
+        doSomething()
+        const value: string = getValue()
+        value.toUpperCase()
+      `,
+      output: `
+        doSomething()
+        ;(getValue() as string).toUpperCase()
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // 型注釈付き変数（メソッドチェーン）
+    {
+      code: `
+        inputs[0].focus()
+        const input: HTMLInputElement = inputs[0]
+        input.setSelectionRange(0, 0)
+      `,
+      output: `
+        inputs[0].focus()
+        ;(inputs[0] as HTMLInputElement).setSelectionRange(0, 0)
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'input' },
+        },
+      ],
+    },
   ],
 })

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -1,0 +1,642 @@
+const rule = require('../rules/best-practice-for-no-unnecessary-variable')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+  },
+})
+
+ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
+  valid: [
+    // 使用箇所がない
+    {
+      code: 'const x = a + b * c',
+    },
+    // 2回以上使用
+    {
+      code: `
+        const x = obj.property
+        console.log(x)
+        console.log(x)
+      `,
+    },
+    // var宣言は除外
+    {
+      code: `
+        var x = array[index]
+        console.log(x)
+      `,
+    },
+    // 分割代入は除外
+    {
+      code: `
+        const [x] = array
+        console.log(x)
+      `,
+    },
+    {
+      code: `
+        const { name } = user
+        console.log(name)
+      `,
+    },
+    // 初期化なしは除外
+    {
+      code: `
+        let x
+        x = condition ? a : b
+        console.log(x)
+      `,
+    },
+    // ループ変数は除外
+    {
+      code: `
+        for (const item of items) {
+          console.log(item)
+        }
+      `,
+    },
+    // ループ内で使用される変数は除外
+    {
+      code: `
+        const x = a + b
+        for (let i = 0; i < 10; i++) {
+          console.log(x)
+        }
+      `,
+    },
+    {
+      code: `
+        const x = obj?.method()
+        while (condition) {
+          console.log(x)
+        }
+      `,
+    },
+    // 関数スコープ内で使用される変数は除外
+    {
+      code: `
+        const x = data.filter(Boolean)
+        array.forEach(() => {
+          console.log(x)
+        })
+      `,
+    },
+    {
+      code: `
+        const x = 'constant'
+        const fn = () => console.log(x)
+      `,
+    },
+    // React Hooks除外
+    {
+      code: `
+        function Component() {
+          const handleClick = useCallback(() => {
+            console.log('clicked')
+          }, [])
+          return handleClick
+        }
+      `,
+    },
+    // await式除外
+    {
+      code: `
+        async function fetchData() {
+          const result = await fetchAPI()
+          console.log(result)
+        }
+      `,
+    },
+    // 2回以上使用（演算式）
+    {
+      code: `
+        const sum = a + b + c
+        console.log(sum)
+        doSomething(sum)
+      `,
+    },
+    // 2回以上使用（配列アクセス）
+    {
+      code: `
+        const first = items[0]
+        doSomething(first)
+        process(first)
+      `,
+    },
+    // 関数スコープ内で宣言・使用（同じスコープ内で2回以上使用）
+    {
+      code: `
+        array.map(() => {
+          const x = getValue()
+          const y = getOther()
+          return x + y + x + y
+        })
+      `,
+    },
+    // return文以外：複雑な式は除外（デフォルトmaxComplexity: 3）
+    {
+      code: `
+        function foo() {
+          const result = obj.method().another().property
+          console.log(result)
+        }
+      `,
+    },
+    // return文：複雑さ以外の除外条件（await）は依然として適用
+    {
+      code: `
+        async function foo() {
+          const result = await fetchData()
+          return result
+        }
+      `,
+    },
+    // maxComplexity: 2 の場合、Complexity 3は除外
+    {
+      code: `
+        const x = obj.method().property
+        console.log(x)
+      `,
+      options: [{ maxComplexity: 2 }],
+    },
+    // maxComplexity: 0 の場合、全て除外
+    {
+      code: `
+        const x = getValue()
+        console.log(x)
+      `,
+      options: [{ maxComplexity: 0 }],
+    },
+    // ネストした三項演算子（Complexity 4）はデフォルトで除外
+    {
+      code: `
+        const x = a ? (b ? c : d) : e
+        console.log(x)
+      `,
+    },
+    // 両側にネストした三項演算子（Complexity 6）はデフォルトで除外
+    {
+      code: `
+        const x = a ? (b ? c : d) : (e ? f : g)
+        console.log(x)
+      `,
+    },
+  ],
+  invalid: [
+    // 基本パターン
+    {
+      code: `
+        const x = a + b * c
+        console.log(x)
+      `,
+      output: `
+        console.log(a + b * c)
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // return文で使用
+    {
+      code: `
+        function foo() {
+          const x = array[0]
+          return x
+        }
+      `,
+      output: `
+        function foo() {
+          return array[0]
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // 関数呼び出しの引数として使用（三項演算子は括弧で囲む）
+    {
+      code: `
+        const x = condition ? value1 : value2
+        doSomething(x)
+      `,
+      output: `
+        doSomething((condition ? value1 : value2))
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // if文内で使用（lazy-variable適用後を想定）
+    {
+      code: `
+        if (condition) {
+          const x = obj.property
+          console.log(x)
+        }
+      `,
+      output: `
+        if (condition) {
+          console.log(obj.property)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // 複雑な式
+    {
+      code: `
+        function foo() {
+          const result = obj.method().property
+          return result
+        }
+      `,
+      output: `
+        function foo() {
+          return obj.method().property
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'result' },
+        },
+      ],
+    },
+    // リテラル値
+    {
+      code: `
+        const value = 42
+        console.log(value)
+      `,
+      output: `
+        console.log(42)
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // オプショナルチェーン
+    {
+      code: `
+        const data = obj?.nested?.property
+        process(data)
+      `,
+      output: `
+        process(obj?.nested?.property)
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'data' },
+        },
+      ],
+    },
+    // 複数の変数宣言（最初のdeclaratorのみが1回使用）
+    {
+      code: `
+        const x = getValue(), y = getOther()
+        console.log(x)
+        console.log(y)
+        console.log(y)
+      `,
+      output: `
+        const y = getOther()
+        console.log(getValue())
+        console.log(y)
+        console.log(y)
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // 複数の変数宣言（2番目のdeclaratorのみが1回使用）
+    {
+      code: `
+        const x = getValue(), y = getOther()
+        console.log(x)
+        console.log(x)
+        console.log(y)
+      `,
+      output: `
+        const x = getValue()
+        console.log(x)
+        console.log(x)
+        console.log(getOther())
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'y' },
+        },
+      ],
+    },
+    // if条件内で使用
+    {
+      code: `
+        const value = getValue()
+        if (value) {
+          doSomething()
+        }
+      `,
+      output: `
+        if (getValue()) {
+          doSomething()
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // 別の変数の初期化で使用
+    {
+      code: `
+        const x = getValue()
+        const y = x + 1
+      `,
+      output: `
+        const y = getValue() + 1
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // 配列リテラル内で使用
+    {
+      code: `
+        const value = getValue()
+        const arr = [1, value, 3]
+      `,
+      output: `
+        const arr = [1, getValue(), 3]
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // オブジェクトリテラル内で使用
+    {
+      code: `
+        const value = getValue()
+        const obj = { key: value }
+      `,
+      output: `
+        const obj = { key: getValue() }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // テンプレートリテラル内で使用
+    {
+      code: `
+        const name = getName()
+        const message = \`Hello, \${name}!\`
+      `,
+      output: `
+        const message = \`Hello, \${getName()}!\`
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'name' },
+        },
+      ],
+    },
+    // switch文の条件で使用
+    {
+      code: `
+        const value = getValue()
+        switch (value) {
+          case 'a':
+            break
+        }
+      `,
+      output: `
+        switch (getValue()) {
+          case 'a':
+            break
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // 関数スコープ内で宣言・使用（同じスコープ内）
+    {
+      code: `
+        array.map(() => {
+          const x = getValue()
+          return x
+        })
+      `,
+      output: `
+        array.map(() => {
+          return getValue()
+        })
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // new式（括弧が必要）
+    {
+      code: `
+        const instance = new MyClass()
+        console.log(instance.property)
+      `,
+      output: `
+        console.log((new MyClass()).property)
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'instance' },
+        },
+      ],
+    },
+    // 三項演算子（括弧が必要）
+    {
+      code: `
+        const result = condition ? value1 : value2
+        const y = result.property
+      `,
+      output: `
+        const y = (condition ? value1 : value2).property
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'result' },
+        },
+      ],
+    },
+    // return文：複雑でもインライン化
+    {
+      code: `
+        function foo() {
+          const result = obj.method().another().property
+          return result
+        }
+      `,
+      output: `
+        function foo() {
+          return obj.method().another().property
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'result' },
+        },
+      ],
+    },
+    // maxComplexity: 5 の場合、Complexity 3はインライン化
+    {
+      code: `
+        const x = obj.method().property
+        console.log(x)
+      `,
+      options: [{ maxComplexity: 5 }],
+      output: `
+        console.log(obj.method().property)
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // LogicalExpression（Complexity 1）
+    {
+      code: `
+        const x = a && b
+        console.log(x)
+      `,
+      output: `
+        console.log(a && b)
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // ConditionalExpression（Complexity 2、括弧が必要）
+    {
+      code: `
+        const x = a ? b : c
+        console.log(x)
+      `,
+      output: `
+        console.log((a ? b : c))
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // return文：複雑でもインライン化（アロー関数）
+    {
+      code: `
+        const getValue = () => {
+          const result = obj.method().another().property
+          return result
+        }
+      `,
+      output: `
+        const getValue = () => {
+          return obj.method().another().property
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'result' },
+        },
+      ],
+    },
+    // ネストした三項演算子（Complexity 4）、maxComplexity: 5 ならインライン化
+    {
+      code: `
+        const x = a ? (b ? c : d) : e
+        console.log(x)
+      `,
+      options: [{ maxComplexity: 5 }],
+      output: `
+        console.log((a ? (b ? c : d) : e))
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // return文：ネストした三項演算子でもインライン化（括弧が必要）
+    {
+      code: `
+        function foo() {
+          const x = a ? (b ? c : d) : e
+          return x
+        }
+      `,
+      output: `
+        function foo() {
+          return (a ? (b ? c : d) : e)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -6,6 +6,9 @@ const ruleTester = new RuleTester({
     parserOptions: {
       ecmaVersion: 2020,
       sourceType: 'module',
+      ecmaFeatures: {
+        jsx: true,
+      },
     },
   },
 })
@@ -257,6 +260,22 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return \`Result: \${result.name}\`
         }
       `,
+    },
+    // JSXElement（Complexity 2）+ console.log（Complexity 2）= 4、maxComplexity: 3で除外
+    {
+      code: `
+        const element = <div>Hello</div>
+        console.log(element)
+      `,
+      options: [{ maxComplexity: 3 }],
+    },
+    // JSXElement with props（Complexity 3）+ render（Complexity 1）= 4、maxComplexity: 3で除外
+    {
+      code: `
+        const element = <Component prop={value.nested} />
+        render(element)
+      `,
+      options: [{ maxComplexity: 3 }],
     },
   ],
   invalid: [
@@ -787,6 +806,46 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         {
           messageId: 'inlineVariable',
           data: { name: 'result' },
+        },
+      ],
+    },
+    // JSXElement（Complexity 2）をreturn文で使用
+    {
+      code: `
+        function Component() {
+          const element = <div>Hello</div>
+          return element
+        }
+      `,
+      output: `
+        function Component() {
+          return <div>Hello</div>
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'element' },
+        },
+      ],
+    },
+    // JSXElement with props（Complexity 2 + MemberExpression）をreturn文で使用
+    {
+      code: `
+        function Component() {
+          const element = <Child prop={value.nested} />
+          return element
+        }
+      `,
+      output: `
+        function Component() {
+          return <Child prop={value.nested} />
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'element' },
         },
       ],
     },

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -186,6 +186,37 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         console.log(x)
       `,
     },
+    // ObjectExpression（Complexity 2）+ console.log（Complexity 2）= 4、maxComplexity: 3で除外
+    {
+      code: `
+        const obj = { a: 1, b: 2 }
+        console.log(obj)
+      `,
+      options: [{ maxComplexity: 3 }],
+    },
+    // ArrayExpression（Complexity 2）+ console.log（Complexity 2）= 4、maxComplexity: 3で除外
+    {
+      code: `
+        const arr = [1, 2, 3]
+        console.log(arr)
+      `,
+      options: [{ maxComplexity: 3 }],
+    },
+    // SpreadElement（Complexity 1）を含むObjectExpression（Complexity 2）+ console.log（Complexity 2）= 5、maxComplexity: 3で除外
+    {
+      code: `
+        const obj = { ...spread, a: 1 }
+        console.log(obj)
+      `,
+      options: [{ maxComplexity: 3 }],
+    },
+    // export宣言された変数は除外
+    {
+      code: `
+        export const messages = { a: 1, b: 2 }
+        const locale = typeof messages
+      `,
+    },
   ],
   invalid: [
     // 基本パターン
@@ -601,13 +632,13 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         },
       ],
     },
-    // ネストした三項演算子（Complexity 4）、maxComplexity: 5 ならインライン化
+    // ネストした三項演算子（Complexity 4）、maxComplexity: 7 ならインライン化
     {
       code: `
         const x = a ? (b ? c : d) : e
         console.log(x)
       `,
-      options: [{ maxComplexity: 5 }],
+      options: [{ maxComplexity: 7 }],
       output: `
         console.log((a ? (b ? c : d) : e))
       `,
@@ -635,6 +666,66 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         {
           messageId: 'inlineVariable',
           data: { name: 'x' },
+        },
+      ],
+    },
+    // ObjectExpression（Complexity 2）をreturn文で使用（return文は括弧が必要）
+    {
+      code: `
+        function foo() {
+          const obj = { a: 1, b: 2 }
+          return obj
+        }
+      `,
+      output: `
+        function foo() {
+          return ({ a: 1, b: 2 })
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'obj' },
+        },
+      ],
+    },
+    // ArrayExpression（Complexity 2）をreturn文で使用
+    {
+      code: `
+        function foo() {
+          const arr = [1, 2, 3]
+          return arr
+        }
+      `,
+      output: `
+        function foo() {
+          return [1, 2, 3]
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'arr' },
+        },
+      ],
+    },
+    // SpreadElementを含むObjectExpression（Complexity 3）をreturn文で使用
+    {
+      code: `
+        function foo() {
+          const obj = { ...spread, a: 1 }
+          return obj
+        }
+      `,
+      output: `
+        function foo() {
+          return ({ ...spread, a: 1 })
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'obj' },
         },
       ],
     },

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -231,6 +231,33 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         console.log(result)
       `,
     },
+    // return文で変数のプロパティを返す場合（単一変数ではない）
+    {
+      code: `
+        function foo() {
+          const result = models.find((model) => model.model === match)
+          return result.name
+        }
+      `,
+    },
+    // return文で変数を関数の引数として使う場合（単一変数ではない）
+    {
+      code: `
+        function foo() {
+          const result = models.find((model) => model.model === match)
+          return Response.json({ message: result.name })
+        }
+      `,
+    },
+    // return文でテンプレートリテラル内で変数を使う場合（単一変数ではない）
+    {
+      code: `
+        function foo() {
+          const result = models.find((model) => model.model === match)
+          return \`Result: \${result.name}\`
+        }
+      `,
+    },
   ],
   invalid: [
     // 基本パターン

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -310,6 +310,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         console.log(a + b * c)
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -330,6 +331,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return array[0]
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -346,6 +348,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         doSomething((condition ? value1 : value2))
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -366,6 +369,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           console.log(obj.property)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -386,6 +390,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return obj.method().property
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -402,6 +407,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         console.log(42)
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -418,6 +424,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         process(obj?.nested?.property)
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -439,6 +446,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         console.log(y)
         console.log(y)
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -460,6 +468,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         console.log(x)
         console.log(getOther())
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -480,6 +489,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           doSomething()
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -496,6 +506,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         const y = getValue() + 1
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -512,6 +523,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         const arr = [1, getValue(), 3]
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -528,6 +540,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         const obj = { key: getValue() }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -544,6 +557,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         const message = \`Hello, \${getName()}!\`
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -566,6 +580,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
             break
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -586,6 +601,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return getValue()
         })
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -602,6 +618,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         console.log((new MyClass()).property)
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -618,6 +635,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         const y = (condition ? value1 : value2).property
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -638,6 +656,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return obj.method().another().property
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -651,7 +670,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         const x = obj.method().property
         console.log(x)
       `,
-      options: [{ maxComplexity: 5 }],
+      options: [{ maxComplexity: 5, fix: true }],
       output: `
         console.log(obj.method().property)
       `,
@@ -671,6 +690,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         console.log(a && b)
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -687,6 +707,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         console.log((a ? b : c))
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -707,6 +728,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return obj.method().another().property
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -720,7 +742,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         const x = a ? (b ? c : d) : e
         console.log(x)
       `,
-      options: [{ maxComplexity: 7 }],
+      options: [{ maxComplexity: 7, fix: true }],
       output: `
         console.log((a ? (b ? c : d) : e))
       `,
@@ -744,6 +766,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return (a ? (b ? c : d) : e)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -764,6 +787,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return ({ a: 1, b: 2 })
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -784,6 +808,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return [1, 2, 3]
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -804,6 +829,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return ({ ...spread, a: 1 })
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -824,6 +850,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return array.map(() => getValue())
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -840,6 +867,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         if (!(value === 'nothing')) allN = false
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -856,6 +884,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         if (typeof (getValue()) === 'string') doSomething()
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -872,6 +901,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         const num = +(getStringValue())
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -888,6 +918,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         const bool = !!(getValue())
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -904,6 +935,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
       output: `
         if (!!(check())) doSomething()
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -922,6 +954,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         inputs[0].focus()
         ;inputs[0].setSelectionRange(0, 0)
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -940,6 +973,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         doSomething()
         ;({ a: 1 }).property()
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -960,6 +994,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return <div>Hello</div>
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
@@ -980,10 +1015,94 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           return <Child prop={value.nested} />
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'inlineVariable',
           data: { name: 'element' },
+        },
+      ],
+    },
+    // fix: false（デフォルト） - 自動修正なし
+    {
+      code: `
+        const x = getValue()
+        console.log(x)
+      `,
+      options: [{ fix: false }],
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // fix: false（デフォルト） - オプション指定なしでも自動修正なし
+    {
+      code: `
+        const x = getValue()
+        console.log(x)
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // fix: true - 自動修正あり
+    {
+      code: `
+        const x = getValue()
+        console.log(x)
+      `,
+      output: `
+        console.log(getValue())
+      `,
+      options: [{ fix: true }],
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'x' },
+        },
+      ],
+    },
+    // fix: true - return文での自動修正
+    {
+      code: `
+        function foo() {
+          const result = obj.method()
+          return result
+        }
+      `,
+      output: `
+        function foo() {
+          return obj.method()
+        }
+      `,
+      options: [{ fix: true }],
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'result' },
+        },
+      ],
+    },
+    // fix: true - 複数変数宣言での自動修正
+    {
+      code: `
+        const x = 1, y = getValue(), z = 3
+        console.log(y)
+      `,
+      output: `
+        const x = 1, z = 3
+        console.log(getValue())
+      `,
+      options: [{ fix: true }],
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'y' },
         },
       ],
     },

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -809,6 +809,54 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         },
       ],
     },
+    // 単項演算子（!）で使用される場合は括弧で囲む
+    {
+      code: `
+        const isNothing = value === 'nothing'
+        if (!isNothing) allN = false
+      `,
+      output: `
+        if (!(value === 'nothing')) allN = false
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'isNothing' },
+        },
+      ],
+    },
+    // 単項演算子（typeof）で使用される場合は括弧で囲む
+    {
+      code: `
+        const result = getValue()
+        if (typeof result === 'string') doSomething()
+      `,
+      output: `
+        if (typeof (getValue()) === 'string') doSomething()
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'result' },
+        },
+      ],
+    },
+    // 単項演算子（+）で使用される場合は括弧で囲む
+    {
+      code: `
+        const str = getStringValue()
+        const num = +str
+      `,
+      output: `
+        const num = +(getStringValue())
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'str' },
+        },
+      ],
+    },
     // JSXElement（Complexity 2）をreturn文で使用
     {
       code: `

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -221,6 +221,27 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         const locale = typeof messages
       `,
     },
+    // UPPER_SNAKE_CASE形式の定数は除外
+    {
+      code: `
+        const NULL = { label: '', value: '' }
+        console.log(NULL)
+      `,
+    },
+    {
+      code: `
+        const API_BASE_URL = 'https://example.com'
+        fetch(API_BASE_URL)
+      `,
+    },
+    {
+      code: `
+        function foo() {
+          const MAX_COUNT_123 = 100
+          return MAX_COUNT_123
+        }
+      `,
+    },
     // ArrowFunctionExpression（Complexity 2）を含む式、デフォルトで除外
     {
       code: `

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -857,6 +857,74 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         },
       ],
     },
+    // ダブル否定（!!）で使用される場合も括弧で囲む
+    {
+      code: `
+        const value = getValue()
+        const bool = !!value
+      `,
+      output: `
+        const bool = !!(getValue())
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'value' },
+        },
+      ],
+    },
+    // ダブル否定（!!）をif文で使用
+    {
+      code: `
+        const isValid = check()
+        if (!!isValid) doSomething()
+      `,
+      output: `
+        if (!!(check())) doSomething()
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'isValid' },
+        },
+      ],
+    },
+    // ExpressionStatementの先頭で使用される場合、セミコロンを前置
+    {
+      code: `
+        inputs[0].focus()
+        const input = inputs[0]
+        input.setSelectionRange(0, 0)
+      `,
+      output: `
+        inputs[0].focus()
+        ;inputs[0].setSelectionRange(0, 0)
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'input' },
+        },
+      ],
+    },
+    // ExpressionStatementの先頭で使用（括弧が必要な場合）
+    {
+      code: `
+        doSomething()
+        const obj = { a: 1 }
+        obj.property()
+      `,
+      output: `
+        doSomething()
+        ;({ a: 1 }).property()
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'obj' },
+        },
+      ],
+    },
     // JSXElement（Complexity 2）をreturn文で使用
     {
       code: `

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -141,7 +141,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         })
       `,
     },
-    // return文以外：複雑な式は除外（デフォルトmaxComplexity: 3）
+    // return文以外：複雑な式は除外（引数なし関数呼び出しはComplexity 0なので、maxComplexity: 4で除外）
     {
       code: `
         function foo() {
@@ -149,6 +149,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
           console.log(result)
         }
       `,
+      options: [{ maxComplexity: 4 }],
     },
     // return文：複雑さ以外の除外条件（await）は依然として適用
     {

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -217,6 +217,20 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         const locale = typeof messages
       `,
     },
+    // ArrowFunctionExpression（Complexity 2）を含む式、デフォルトで除外
+    {
+      code: `
+        const result = array.map(() => getValue())
+        console.log(result)
+      `,
+    },
+    // FunctionExpression（Complexity 2）を含む式、デフォルトで除外
+    {
+      code: `
+        const result = array.map(function() { return getValue() })
+        console.log(result)
+      `,
+    },
   ],
   invalid: [
     // 基本パターン
@@ -726,6 +740,26 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         {
           messageId: 'inlineVariable',
           data: { name: 'obj' },
+        },
+      ],
+    },
+    // ArrowFunctionExpression（Complexity 2）を含む式をreturn文で使用
+    {
+      code: `
+        function foo() {
+          const result = array.map(() => getValue())
+          return result
+        }
+      `,
+      output: `
+        function foo() {
+          return array.map(() => getValue())
+        }
+      `,
+      errors: [
+        {
+          messageId: 'inlineVariable',
+          data: { name: 'result' },
         },
       ],
     },


### PR DESCRIPTION
## Summary
一度しか使用されていない変数を直接インライン化するESLintルールを追加しました。

### 主な機能
- 1回のみ使用される変数の自動インライン化
- 複雑さベースのフィルタリング（デフォルト: maxComplexity 5）
- TypeScript型注釈の保持（`as`構文に変換）
- セミコロン前置によるメソッドチェーン防止
- 単項演算子での括弧自動追加
- 引数なし関数呼び出しを複雑さ0として扱う
- UPPER_SNAKE_CASE形式の定数を除外

### 変更内容
- `libs/ast-utils.js`: 複雑さ計算とユーティリティ関数追加
- `rules/best-practice-for-no-unnecessary-variable/`: 新ルール実装
- テストケース: 991行（JavaScript + TypeScript）
- ドキュメント: 使用例と設定方法

### 実プロダクトでの検証結果（hanica/client）
- 265ファイル、1374行追加、2095行削除（純減721行）
- TypeScript型チェック成功
- 主な効果:
  - `generateId()`等の引数なし関数のインライン化
  - テストコードの簡潔化
  - 定数命名規則の保持

### 複雑さ計算の仕様
**+1:** プロパティアクセス、演算子、new、spread、型アサーション、引数あり関数呼び出し  
**+2:** 三項演算子、オブジェクト/配列リテラル、関数式、JSX要素  
**+0:** 引数なし関数呼び出し、Identifier

### 除外パターン
- `var`宣言
- 分割代入
- ループ変数
- await式を含む変数
- React Hooks（useXxx）
- 関数式/アロー関数
- export宣言
- UPPER_SNAKE_CASE定数

## Test plan
- [x] 単体テスト: 1561テスト通過
- [x] TypeScript型チェック成功
- [x] 実プロダクト検証（hanica）: 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)