### PR TITLE
chore: restore oxlint-config-smarthr dependencies

### DIFF
--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -28,8 +28,10 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
+  "dependencies": {
+    "eslint-plugin-smarthr": ">=6.14.0"
+  },
   "peerDependencies": {
-    "eslint-plugin-smarthr": ">=6.14.0",
     "oxlint": ">=1.0.0"
   }
 }


### PR DESCRIPTION
## Summary

#1322 で誤って `peerDependencies` に戻ってしまった `eslint-plugin-smarthr` を `dependencies` に再度移動します。

## 背景

- #1338 で `oxlint-config-smarthr` の `eslint-plugin-smarthr` を `peerDependencies` から `dependencies` に移動
- #1322 (Renovate PR) で誤って `peerDependencies` に戻ってしまった
- この変更により、oxlintがesmarthr-pluginのルールを見つけられない状態になっていた

## 変更内容

- `packages/oxlint-config-smarthr/package.json`
  - `eslint-plugin-smarthr` を `peerDependencies` から `dependencies` に移動

## テスト

全テスト通過確認済み (1519 passed)

## 関連

- #1338
- #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)