### PR TITLE
feat: eslint-plugin-smarthrを6.17.0に更新 (eslint-config-smarthr)

### DIFF
--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -60,6 +60,7 @@ export default [
       'smarthr/best-practice-for-data-test-attribute': 'off',
       'smarthr/best-practice-for-default-props': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
       'smarthr/best-practice-for-interactive-element': 'error',
+      'smarthr/best-practice-for-lazy-variable': 'warn', // TODO: 2026/06にwarn化。問題なければerrorに変更予定
       'smarthr/best-practice-for-layouts': 'error',
       'smarthr/best-practice-for-nested-attributes-array-index': 'error',
       'smarthr/best-practice-for-optional-chaining': 'error',

--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-smarthr": "6.16.0",
+    "eslint-plugin-smarthr": "6.17.0",
     "globals": "^17.6.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
@@ -3057,6 +3057,9 @@ exports[`should match ESLint Configuration snapshot 1`] = `
     "smarthr/best-practice-for-layouts": [
       2,
     ],
+    "smarthr/best-practice-for-lazy-variable": [
+      1,
+    ],
     "smarthr/best-practice-for-nested-attributes-array-index": [
       2,
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.16.0
-        version: 6.16.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.17.0
+        version: 6.17.0(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -3579,6 +3579,11 @@ packages:
 
   eslint-plugin-smarthr@6.16.0:
     resolution: {integrity: sha512-yU+cmtEnogu2ef0AVwu80v8+RQIPDfXNKMGfSWGbuY6qzdVvfxnXLRT5azmpEgwv+nNpz61FBpRq7OvxZo010A==}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.17.0:
+    resolution: {integrity: sha512-TGhvilqMICZjRfkLY0ZdXUS2ZlNClXnDJoNBz3YY+D+f83MVYvscbNSES9r31bkJzCcOX17Ys940O1a2U8SMsw==}
     peerDependencies:
       eslint: ^9
 
@@ -10008,6 +10013,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.16.0(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.17.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

- eslint-plugin-smarthr を 6.16.0 → 6.17.0 に更新
- `best-practice-for-lazy-variable` ルールを `warn` で追加

## 変更内容

### eslint-config-smarthr

- `eslint-plugin-smarthr` のバージョンを 6.17.0 に更新
- `smarthr/best-practice-for-lazy-variable` を `warn` で追加
  - TODO: 2026/06にwarn化。問題なければerrorに変更予定

## テスト

- スナップショットテスト更新済み
- 全テスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)