### PR TITLE
feat: eslint-plugin-smarthrを6.17.0に更新 (oxlint-config-smarthr)

### DIFF
--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -222,6 +222,7 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-data-test-attribute': 'off',
     'eslint-plugin-smarthr/best-practice-for-default-props': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
     'eslint-plugin-smarthr/best-practice-for-interactive-element': 'error',
+    'eslint-plugin-smarthr/best-practice-for-lazy-variable': 'warn', // TODO: 2026/06にwarn化。問題なければerrorに変更予定
     'eslint-plugin-smarthr/best-practice-for-layouts': 'error',
     'eslint-plugin-smarthr/best-practice-for-nested-attributes-array-index': 'error',
     'eslint-plugin-smarthr/best-practice-for-optional-chaining': 'error',

--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -29,7 +29,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "eslint-plugin-smarthr": ">=6.16.0"
+    "eslint-plugin-smarthr": ">=6.17.0"
   },
   "peerDependencies": {
     "oxlint": ">=1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
   packages/oxlint-config-smarthr:
     dependencies:
       eslint-plugin-smarthr:
-        specifier: '>=6.16.0'
-        version: 6.16.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: '>=6.17.0'
+        version: 6.17.0(eslint@9.39.4(jiti@2.4.2))
       oxlint:
         specifier: '>=1.0.0'
         version: 1.59.0
@@ -3579,6 +3579,11 @@ packages:
 
   eslint-plugin-smarthr@6.16.0:
     resolution: {integrity: sha512-yU+cmtEnogu2ef0AVwu80v8+RQIPDfXNKMGfSWGbuY6qzdVvfxnXLRT5azmpEgwv+nNpz61FBpRq7OvxZo010A==}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.17.0:
+    resolution: {integrity: sha512-TGhvilqMICZjRfkLY0ZdXUS2ZlNClXnDJoNBz3YY+D+f83MVYvscbNSES9r31bkJzCcOX17Ys940O1a2U8SMsw==}
     peerDependencies:
       eslint: ^9
 
@@ -10008,6 +10013,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.16.0(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.17.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

- eslint-plugin-smarthr を >=6.16.0 → >=6.17.0 に更新
- `best-practice-for-lazy-variable` ルールを `warn` で追加

## 変更内容

### oxlint-config-smarthr

- `eslint-plugin-smarthr` の最小バージョンを >=6.17.0 に更新
- `eslint-plugin-smarthr/best-practice-for-lazy-variable` を `warn` で追加
  - TODO: 2026/06にwarn化。問題なければerrorに変更予定

## テスト

- 全テスト通過確認 (1519 passed)
- oxlint-config-smarthr test: Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)