### PR TITLE
feat: best-practice-for-lazy-variable に fix オプション追加

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-lazy-variable/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-lazy-variable/README.md
@@ -35,7 +35,7 @@ if (condition) {
 ```js
 {
   rules: {
-    'smarthr/best-practice-for-lazy-variable': 'error', // 'warn', 'off'
+    'smarthr/best-practice-for-lazy-variable': ['error', { fix: false }],  // デフォルト: 自動修正無効
   },
 }
 ```
@@ -222,9 +222,49 @@ for (const item of items) {
 }
 ```
 
+## options
+
+### fix
+
+自動修正を有効にするかどうかを指定します。
+
+**デフォルト値**: `false`
+
+```js
+{
+  rules: {
+    'smarthr/best-practice-for-lazy-variable': ['error', { fix: true }],
+  },
+}
+```
+
+#### ⚠️ 自動修正の注意点
+
+自動修正を有効にすると、変数宣言が使用箇所の直前に移動されます。
+
+**副作用を持つ関数の場合、実行順序が変わる可能性があります**:
+
+```js
+// Before（副作用を持つ関数の場合）
+const value = sideEffect1()  // ← 先に実行される
+sideEffect2()
+if (condition) {
+  console.log(value)
+}
+
+// After（自動修正後）
+sideEffect2()  // ← 先に実行される
+if (condition) {
+  const value = sideEffect1()
+  console.log(value)
+}
+```
+
+このため、デフォルトでは自動修正を無効にしています。自動修正を使う前に、手動で確認することを推奨します。
+
 ## autofix
 
-このルールは自動修正に対応しています。
+このルールは自動修正に対応しています。自動修正を有効にするには `fix: true` オプションを指定してください。
 
 ### 移動パターン
 

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-lazy-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-lazy-variable/index.js
@@ -7,7 +7,18 @@ const {
   containsAwait,
 } = require('../../libs/ast-utils')
 
-const SCHEMA = []
+const SCHEMA = [
+  {
+    type: 'object',
+    properties: {
+      fix: {
+        type: 'boolean',
+        default: false,
+      },
+    },
+    additionalProperties: false,
+  },
+]
 
 const EARLY_EXIT_STATEMENT_TYPES = new Set([
   'ReturnStatement',
@@ -768,6 +779,8 @@ module.exports = {
   },
   create(context) {
     const sourceCode = context.sourceCode || context.getSourceCode()
+    const options = context.options[0] || {}
+    const fix = options.fix
 
     return {
       'VariableDeclarator': (node) => {
@@ -778,13 +791,13 @@ module.exports = {
           node: analysis.node,
           messageId: 'moveToLazy',
           data: { name: analysis.varName },
-          fix: createMoveFixer(
+          fix: fix ? createMoveFixer(
             sourceCode,
             analysis.variableDeclaration,
             analysis.targetBody,
             analysis.insertBeforeStatement,
             analysis.firstUsageStatement
-          ),
+          ) : null,
         })
       },
     }

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-lazy-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-lazy-variable.js
@@ -433,6 +433,7 @@ ruleTester.run('best-practice-for-lazy-variable', rule, {
           console.log(data)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -456,6 +457,7 @@ ruleTester.run('best-practice-for-lazy-variable', rule, {
           console.log(x)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -483,6 +485,7 @@ ruleTester.run('best-practice-for-lazy-variable', rule, {
           console.log(x)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -510,6 +513,7 @@ ruleTester.run('best-practice-for-lazy-variable', rule, {
           console.log(x)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -531,6 +535,7 @@ const x = getValue()
 console.log(x)
 }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -558,6 +563,7 @@ console.log(x)
           console.log(x)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -579,6 +585,7 @@ console.log(x)
           console.log(x)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -603,6 +610,7 @@ switch (condition) {
     break
   }
 }`,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -637,6 +645,7 @@ switch (condition) {
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -680,6 +689,7 @@ switch (condition) {
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -707,6 +717,7 @@ switch (condition) {
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -739,6 +750,7 @@ switch (condition) {
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -770,6 +782,7 @@ switch (condition) {
             break
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -801,6 +814,7 @@ switch (condition) {
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -837,6 +851,7 @@ switch (condition) {
             break
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -868,6 +883,7 @@ switch (condition) {
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -891,6 +907,7 @@ switch (condition) {
           console.log(x)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -916,6 +933,7 @@ const x = getValue()
 console.log(x)
 }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -947,6 +965,7 @@ console.log(x)
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -974,6 +993,7 @@ console.log(x)
           console.log(x)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1006,6 +1026,7 @@ console.log(x)
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1039,6 +1060,7 @@ console.log(x)
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1072,6 +1094,7 @@ console.log(x)
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1105,6 +1128,7 @@ console.log(x)
           })
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1143,6 +1167,7 @@ console.log(x)
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1174,6 +1199,7 @@ console.log(x)
           console.log(x)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1201,6 +1227,7 @@ console.log(x)
           console.log(data)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1228,6 +1255,7 @@ console.log(x)
           console.log(user)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1255,6 +1283,7 @@ console.log(x)
           return value
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1294,6 +1323,7 @@ console.log(x)
           console.log(data)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1331,6 +1361,7 @@ console.log(x)
           console.log(data)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1368,6 +1399,7 @@ console.log(x)
           console.log(data)
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1401,6 +1433,7 @@ console.log(x)
         const data = getData()
         console.log(data)
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1430,6 +1463,7 @@ console.log(x)
         const data = getData()
         console.log(data)
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1463,6 +1497,7 @@ console.log(x)
         const data = getData()
         console.log(data)
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1490,6 +1525,7 @@ console.log(x)
           doSomething()
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
@@ -1517,10 +1553,68 @@ console.log(x)
           }
         }
       `,
+      options: [{ fix: true }],
       errors: [
         {
           messageId: 'moveToLazy',
           data: { name: 'name' },
+        },
+      ],
+    },
+    // fix: false（デフォルト） - 自動修正なし
+    {
+      code: `
+        const data = fetchData()
+        doWork()
+        if (needsData) {
+          process(data)
+        }
+      `,
+      options: [{ fix: false }],
+      errors: [
+        {
+          messageId: 'moveToLazy',
+          data: { name: 'data' },
+        },
+      ],
+    },
+    // fix: false（デフォルト） - オプション指定なしでも自動修正なし
+    {
+      code: `
+        const result = calculate()
+        log()
+        if (shouldUse) {
+          apply(result)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'moveToLazy',
+          data: { name: 'result' },
+        },
+      ],
+    },
+    // fix: true - 自動修正あり
+    {
+      code: `
+        const value = compute()
+        prepare()
+        if (ready) {
+          use(value)
+        }
+      `,
+      output: `
+        prepare()
+        if (ready) {
+          const value = compute()
+          use(value)
+        }
+      `,
+      options: [{ fix: true }],
+      errors: [
+        {
+          messageId: 'moveToLazy',
+          data: { name: 'value' },
         },
       ],
     },


### PR DESCRIPTION
## Summary

`best-practice-for-lazy-variable` ルールに `fix` オプションを追加し、デフォルトで自動修正を無効にしました。

## 変更内容

- **`fix` オプションの追加**
  - デフォルト値: `false`（自動修正無効）
  - `fix: true` を明示的に指定した場合のみ自動修正が実行される

- **ドキュメント更新**
  - `options` セクション追加
  - 副作用を持つ関数での実行順序変更に関する警告を追加
  - デフォルトで自動修正が無効であることを明記

- **テストケース追加**
  - `fix: false` の動作確認（エラー報告のみ、自動修正なし）
  - `fix: true` の動作確認（自動修正あり）
  - 既存のテストケース（`output` あり）に `options: [{ fix: true }]` を追加

## 理由

副作用を持つ関数の場合、変数宣言の移動により実行順序が変わる可能性があります：

```js
// Before（副作用を持つ関数の場合）
const value = sideEffect1()  // ← 先に実行される
sideEffect2()
if (condition) {
  console.log(value)
}

// After（自動修正後）
sideEffect2()  // ← 先に実行される
if (condition) {
  const value = sideEffect1()
  console.log(value)
}
```

このため、デフォルトでは自動修正を無効にし、ユーザーが意図的に有効化する必要があります。

## 関連PR

- #1339 (`best-practice-for-no-unnecessary-variable` の同様の対応)

## Test plan

- [x] `npm test -- test/best-practice-for-lazy-variable.js` 成功
- [x] `npm test` 全体テスト成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)