### PR TITLE
feat: oxlint-config-smarthrでeslint-plugin-smarthrを6.19.0に更新

### DIFF
--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -29,7 +29,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "eslint-plugin-smarthr": "6.18.0"
+    "eslint-plugin-smarthr": "6.19.0"
   },
   "peerDependencies": {
     "oxlint": ">=1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
   packages/oxlint-config-smarthr:
     dependencies:
       eslint-plugin-smarthr:
-        specifier: 6.18.0
-        version: 6.18.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.19.0
+        version: 6.19.0(eslint@9.39.4(jiti@2.4.2))
       oxlint:
         specifier: '>=1.0.0'
         version: 1.59.0
@@ -3562,6 +3562,11 @@ packages:
 
   eslint-plugin-smarthr@6.18.0:
     resolution: {integrity: sha512-0vNKLSjpkTO4zH7C93RYiLKPzpxLJjlV8NZRDgSEKSBB8MJzNa26Vbe7G6HDdeY2d94KMwRDdkVA8Fjo7yrLGQ==}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.19.0:
+    resolution: {integrity: sha512-UeXIYOyuubjjEWRqLj+MhzfbhURHVSoEM67RCA0m+yaxhRkF7PafPNexHDXRdT10hVqAdzP1RDcZrIt+DG8aXw==}
     peerDependencies:
       eslint: ^9
 
@@ -9961,6 +9966,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.18.0(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.19.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

- eslint-plugin-smarthr を 6.18.0 → 6.19.0 に更新

## Test plan

- [x] テストpass確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)