### PR TITLE
fix: best-practice-for-rest-parametersでin演算子も内部属性アクセスとして検知

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-rest-parameters/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-rest-parameters/index.js
@@ -50,6 +50,12 @@ module.exports = {
       [`:not(:matches(RestElement,JSXSpreadAttribute,JSXSpreadAttribute > TSAsExpression,SpreadElement,SpreadElement > TSAsExpression,MemberExpression,BinaryExpression,VariableDeclarator,ArrayExpression,CallExpression,ObjectPattern > Property,ObjectExpression > Property,ReturnStatement,ArrowFunctionExpression)) > Identifier[name=${REST_REGEX}]`]: actionNotRest,
       [`:matches(VariableDeclarator[id.name=${REST_REGEX}],ObjectPattern > Property[value.name=${REST_REGEX}],ObjectExpression > Property[key.name=${REST_REGEX}])`]: actionNotRest,
       [`MemberExpression[object.name=${REST_REGEX}]`]: actionMemberExpressionName,
+      [`BinaryExpression[operator="in"][right.name=${REST_REGEX}]`]: (node) => {
+        context.report({
+          node: node.right,
+          message: `残余引数内の属性を参照しないでください${DETAIL_LINK}`,
+        })
+      },
       [`ArrowFunctionExpression > Identifier[name=${REST_REGEX}]`]: (node) => {
         if (node !== node.parent.body) {
           actionNotRest(node)

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-rest-parameters/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-rest-parameters/index.js
@@ -2,6 +2,15 @@ const SCHEMA = []
 
 const REST_REGEX = /(^r|R)est$/
 const MEMBER_EXPRESSION_REST_REGEX = /^(r|[a-zA-Z0-9_]+R)est\./
+
+const UNFORMAT_NAME__REST_ELEMENT_SELECTOR = `RestElement:not([argument.name=${REST_REGEX}])`
+const CONFUSING_NAME_VARIABLE_SELECTOR_1 = `:not(:matches(RestElement,JSXSpreadAttribute,JSXSpreadAttribute > TSAsExpression,SpreadElement,SpreadElement > TSAsExpression,MemberExpression,BinaryExpression,VariableDeclarator,ArrayExpression,CallExpression,ObjectPattern > Property,ObjectExpression > Property,ReturnStatement,ArrowFunctionExpression)) > Identifier[name=${REST_REGEX}]`
+const CONFUSING_NAME_VARIABLE_SELECTOR_2 = `:matches(VariableDeclarator[id.name=${REST_REGEX}],ObjectPattern > Property[value.name=${REST_REGEX}],ObjectExpression > Property[key.name=${REST_REGEX}])`
+const ARROW_FUNCTION_PARAMS_SELECTOR = `ArrowFunctionExpression > Identifier[name=${REST_REGEX}]`
+const USE_REST_VIORATION_SELECTOR_MEMBER_EXPRESSION = `MemberExpression[object.name=${REST_REGEX}]`
+const USE_REST_VIORATION_SELECTOR_IN_OPERATOR = `BinaryExpression[operator="in"][right.name=${REST_REGEX}]`
+const USE_REST_VIORATION_OBJECT_PATTERN = `VariableDeclarator[id.type='ObjectPattern'][init.name=${REST_REGEX}]`
+
 const DETAIL_LINK = `
  - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-rest-parameters`
 
@@ -21,52 +30,47 @@ module.exports = {
  - 残余引数(rest parameters)と混同する可能性があるため別の名称に修正してください`,
       })
     }
+    const actionUseRestVioration = (node) => {
+      context.report({
+        node,
+        message: `残余引数内の属性を参照しないでください${DETAIL_LINK}`,
+      })
+    }
     const actionMemberExpressionName = (node) => {
       if (node.parent.type === 'MemberExpression') {
         return actionMemberExpressionName(node.parent)
       }
 
       if (MEMBER_EXPRESSION_REST_REGEX.test(context.sourceCode.getText(node))){
-        context.report({
-          node,
-          message: `残余引数内の属性を参照しないでください${DETAIL_LINK}`,
-        })
+        actionUseRestVioration(node)
       }
     }
 
     return {
-      [`ObjectPattern[properties.length=1]>RestElement`]: (node) => {
+      'ObjectPattern[properties.length=1]>RestElement': (node) => {
         context.report({
           node,
           message: `意味のない残余引数のため、単一の引数に変更してください${DETAIL_LINK}`,
         })
       },
-      [`RestElement:not([argument.name=${REST_REGEX}])`]: (node) => {
+      [UNFORMAT_NAME__REST_ELEMENT_SELECTOR]: (node) => {
         context.report({
           node,
           message: `残余引数には ${REST_REGEX} とマッチする名称を指定してください${DETAIL_LINK}`,
         })
       },
-      [`:not(:matches(RestElement,JSXSpreadAttribute,JSXSpreadAttribute > TSAsExpression,SpreadElement,SpreadElement > TSAsExpression,MemberExpression,BinaryExpression,VariableDeclarator,ArrayExpression,CallExpression,ObjectPattern > Property,ObjectExpression > Property,ReturnStatement,ArrowFunctionExpression)) > Identifier[name=${REST_REGEX}]`]: actionNotRest,
-      [`:matches(VariableDeclarator[id.name=${REST_REGEX}],ObjectPattern > Property[value.name=${REST_REGEX}],ObjectExpression > Property[key.name=${REST_REGEX}])`]: actionNotRest,
-      [`MemberExpression[object.name=${REST_REGEX}]`]: actionMemberExpressionName,
-      [`BinaryExpression[operator="in"][right.name=${REST_REGEX}]`]: (node) => {
-        context.report({
-          node: node.right,
-          message: `残余引数内の属性を参照しないでください${DETAIL_LINK}`,
-        })
-      },
-      [`ArrowFunctionExpression > Identifier[name=${REST_REGEX}]`]: (node) => {
+      [CONFUSING_NAME_VARIABLE_SELECTOR_1]: actionNotRest,
+      [CONFUSING_NAME_VARIABLE_SELECTOR_2]: actionNotRest,
+      [ARROW_FUNCTION_PARAMS_SELECTOR]: (node) => {
         if (node !== node.parent.body) {
           actionNotRest(node)
         }
       },
-      [`VariableDeclarator[id.type='ObjectPattern'][init.name=${REST_REGEX}]`]: (node) => {
-        context.report({
-          node,
-          message: `残余引数内の属性を参照しないでください${DETAIL_LINK}`,
-        })
+      [USE_REST_VIORATION_SELECTOR_MEMBER_EXPRESSION]: actionMemberExpressionName,
+      [USE_REST_VIORATION_SELECTOR_IN_OPERATOR]: (node) => {
+        actionUseRestVioration(node.right)
       },
+      [USE_REST_VIORATION_OBJECT_PATTERN]: actionUseRestVioration,
     }
   },
 }

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-rest-parameters/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-rest-parameters/index.js
@@ -47,7 +47,7 @@ module.exports = {
           message: `残余引数には ${REST_REGEX} とマッチする名称を指定してください${DETAIL_LINK}`,
         })
       },
-      [`:not(:matches(RestElement,JSXSpreadAttribute,JSXSpreadAttribute > TSAsExpression,SpreadElement,SpreadElement > TSAsExpression,MemberExpression,VariableDeclarator,ArrayExpression,CallExpression,ObjectPattern > Property,ObjectExpression > Property,ReturnStatement,ArrowFunctionExpression)) > Identifier[name=${REST_REGEX}]`]: actionNotRest,
+      [`:not(:matches(RestElement,JSXSpreadAttribute,JSXSpreadAttribute > TSAsExpression,SpreadElement,SpreadElement > TSAsExpression,MemberExpression,BinaryExpression,VariableDeclarator,ArrayExpression,CallExpression,ObjectPattern > Property,ObjectExpression > Property,ReturnStatement,ArrowFunctionExpression)) > Identifier[name=${REST_REGEX}]`]: actionNotRest,
       [`:matches(VariableDeclarator[id.name=${REST_REGEX}],ObjectPattern > Property[value.name=${REST_REGEX}],ObjectExpression > Property[key.name=${REST_REGEX}])`]: actionNotRest,
       [`MemberExpression[object.name=${REST_REGEX}]`]: actionMemberExpressionName,
       [`ArrowFunctionExpression > Identifier[name=${REST_REGEX}]`]: (node) => {

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-rest-parameters.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-rest-parameters.js
@@ -39,8 +39,6 @@ ruleTester.run('best-practice-for-rest-parameters', rule, {
       }
     ` },
     { code: `const removeIdAttr = ({ id: _id, ...rest }) => rest` },
-    { code: `const hoge = (...rest) => { if ('userMap' in rest) return null }` },
-    { code: `const hoge = ({ id, ...rest }) => 'key' in rest` },
   ],
   invalid: [
     { code: `const hoge = ({ ...rest }) => {}`, errors: [ { message: `意味のない残余引数のため、単一の引数に変更してください${DETAIL_LINK}` } ] },
@@ -56,8 +54,11 @@ ruleTester.run('best-practice-for-rest-parameters', rule, {
     { code: `const hoge = rest.hoge`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
     { code: `const hoge = anyRest.hoge.fuga`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
     { code: `const { any } = rest`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
-    // in演算子の右辺のrestはエラーにならないが、プロパティアクセスはエラーになる
-    { code: `const hoge = (...rest) => { if ('userMap' in rest) return rest.userMap }`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
+    // in演算子の右辺も内部属性へのアクセスなのでエラー
+    { code: `const hoge = (...rest) => { if ('userMap' in rest) return null }`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
+    { code: `const hoge = ({ id, ...rest }) => 'key' in rest`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
+    // in演算子とプロパティアクセスの両方でエラー（2つ）
+    { code: `const hoge = (...rest) => { if ('userMap' in rest) return rest.userMap }`, errors: [ { message: ERROR_REST_CHILD_REF }, { message: ERROR_REST_CHILD_REF } ] },
   ]
 })
 

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-rest-parameters.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-rest-parameters.js
@@ -39,6 +39,8 @@ ruleTester.run('best-practice-for-rest-parameters', rule, {
       }
     ` },
     { code: `const removeIdAttr = ({ id: _id, ...rest }) => rest` },
+    { code: `const hoge = (...rest) => { if ('userMap' in rest) return null }` },
+    { code: `const hoge = ({ id, ...rest }) => 'key' in rest` },
   ],
   invalid: [
     { code: `const hoge = ({ ...rest }) => {}`, errors: [ { message: `意味のない残余引数のため、単一の引数に変更してください${DETAIL_LINK}` } ] },
@@ -54,6 +56,8 @@ ruleTester.run('best-practice-for-rest-parameters', rule, {
     { code: `const hoge = rest.hoge`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
     { code: `const hoge = anyRest.hoge.fuga`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
     { code: `const { any } = rest`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
+    // in演算子の右辺のrestはエラーにならないが、プロパティアクセスはエラーになる
+    { code: `const hoge = (...rest) => { if ('userMap' in rest) return rest.userMap }`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
   ]
 })
 

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-rest-parameters.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-rest-parameters.js
@@ -39,6 +39,8 @@ ruleTester.run('best-practice-for-rest-parameters', rule, {
       }
     ` },
     { code: `const removeIdAttr = ({ id: _id, ...rest }) => rest` },
+    // in演算子のleftにrestがあるケースは検知しない（rightのみ検知）
+    { code: `const hoge = (...rest) => { if (rest in obj) return null }` },
   ],
   invalid: [
     { code: `const hoge = ({ ...rest }) => {}`, errors: [ { message: `意味のない残余引数のため、単一の引数に変更してください${DETAIL_LINK}` } ] },
@@ -59,6 +61,12 @@ ruleTester.run('best-practice-for-rest-parameters', rule, {
     { code: `const hoge = ({ id, ...rest }) => 'key' in rest`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
     // in演算子とプロパティアクセスの両方でエラー（2つ）
     { code: `const hoge = (...rest) => { if ('userMap' in rest) return rest.userMap }`, errors: [ { message: ERROR_REST_CHILD_REF }, { message: ERROR_REST_CHILD_REF } ] },
+    // 極端なケース: rest in rest（rightのrestのみエラー）
+    { code: `const hoge = (...rest) => { if (rest in rest) return null }`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
+    // hogeRest in rest（rightのrestにエラー）
+    { code: `const hoge = (...rest) => { if (hogeRest in rest) return null }`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
+    // rest in hogeRest（rightのhogeRestにエラー）
+    { code: `const hoge = ({ id, ...rest }) => { if (rest in hogeRest) return null }`, errors: [ { message: ERROR_REST_CHILD_REF } ] },
   ]
 })
 


### PR DESCRIPTION
## Summary

`best-practice-for-rest-parameters`ルールで、`in`演算子での残余引数使用も内部属性へのアクセスとして正しく検知するように修正。

## 問題

### 元々の問題

```javascript
if ('userMap' in rest) return rest.userMap
```

このコードで、以下の2つのエラーが報告されていた：
1. `'userMap' in rest`の`rest` → 「**残余引数以外にrestを使うな**」（❌ 誤ったエラーメッセージ）
2. `rest.userMap` → 「残余引数内の属性を参照しないでください」（✅ 正しい）

### 当初の修正の問題

`BinaryExpression`を除外リストに追加することで、1の誤ったエラーメッセージは消えたが、`'userMap' in rest`が完全に許可されてしまった。

しかし、**これは誤り**。`'userMap' in rest`も`rest.userMap`と同様に、restの内部構造に関心を持っているため、「restは関心の低い属性をまとめる」というルールの根本に違反している。

## 正しい修正内容

1. **`BinaryExpression`を除外リストに残す**
   - 50行目のセレクターで誤ったエラーメッセージ「残余引数以外にrestを使うな」が出ないようにする

2. **`in`演算子専用のセレクターを追加**
   - `BinaryExpression[operator="in"][right.name=${REST_REGEX}]`
   - 正しいエラーメッセージ「残余引数内の属性を参照しないでください」を出す

## 修正後の動作

```javascript
if ('userMap' in rest) return rest.userMap
```

**2つのエラー（両方とも正しい）:**
1. `'userMap' in rest` → 「残余引数内の属性を参照しないでください」✅
2. `rest.userMap` → 「残余引数内の属性を参照しないでください」✅

## Test plan

- [x] 既存テスト全てpass (30 tests)
- [x] テストケース修正
  - `in`演算子の使用をvalidからinvalidに移動
  - `if ('userMap' in rest) return rest.userMap`で2つのエラーが報告されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)