### PR TITLE
feat(best-practice-for-no-unnecessary-variable): export { xxx as yyy } パターンで適切なメッセージを表示

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -50,9 +50,7 @@ function shouldSkipVariableExceptComplexity(node) {
     // UPPER_SNAKE_CASE形式の定数は除外（慣習的な定数命名）
     UPPER_SNAKE_CASE_PATTERN.test(node.id.name) ||
     // 関数式、TaggedTemplateExpressionは除外
-    EXCLUDED_INIT_TYPES.includes(node.init.type) ||
-    // React Hooks（useXxxで始まる関数）で初期化される変数は対象外
-    (node.init.type === 'CallExpression' && node.init.callee.type === 'Identifier' && node.init.callee.name.startsWith('use'))
+    EXCLUDED_INIT_TYPES.includes(node.init.type)
   ) {
     return true
   }
@@ -67,6 +65,16 @@ function shouldSkipVariableExceptComplexity(node) {
   }
 
   return false
+}
+
+/**
+ * React Hooksで初期化されているかを判定
+ */
+function isReactHookCall(node) {
+  return node.init &&
+         node.init.type === 'CallExpression' &&
+         node.init.callee.type === 'Identifier' &&
+         node.init.callee.name.startsWith('use')
 }
 
 /**
@@ -372,6 +380,24 @@ function isAtStartOfExpressionStatement(usageNode) {
 }
 
 /**
+ * 使用箇所がexport { xxx as yyy }のExportSpecifierの中にあるかチェック
+ */
+function isInExportSpecifier(usageNode) {
+  let current = usageNode.parent
+  while (current) {
+    if (current.type === 'ExportSpecifier') {
+      return true
+    }
+    // ExportNamedDeclarationまで到達したら終了
+    if (current.type === 'ExportNamedDeclaration') {
+      return false
+    }
+    current = current.parent
+  }
+  return false
+}
+
+/**
  * 複雑さをチェックしてインライン化可能かを判定
  */
 function checkComplexity(sourceCode, node, usage, typeAnnotation, maxComplexity) {
@@ -413,6 +439,13 @@ function analyzeVariable(sourceCode, node, options = {}) {
   }
 
   const usage = usages[0]
+  const isExportSpec = isInExportSpecifier(usage)
+
+  // React Hooks呼び出しは対象外（ただしexport { xxx as yyy }パターンは対象）
+  if (!isExportSpec && isReactHookCall(node)) {
+    return null
+  }
+
   const typeAnnotation = getTypeAnnotationText(sourceCode, node)
 
   // 複雑さチェック
@@ -425,6 +458,7 @@ function analyzeVariable(sourceCode, node, options = {}) {
     varName,
     usage,
     typeAnnotation,
+    isExportSpecifier: isExportSpec,
   }
 }
 
@@ -438,6 +472,7 @@ module.exports = {
     schema: SCHEMA,
     messages: {
       inlineVariable: '変数"{{name}}"は一度しか使用されていません。直接使用してください。',
+      exportDirectly: '変数"{{name}}"は一度しか使用されていません。export const {{exportedName}} = ... の形式で直接エクスポートしてください。',
     },
   },
   create(context) {
@@ -450,12 +485,35 @@ module.exports = {
         const analysis = analyzeVariable(sourceCode, node, options)
 
         if (analysis) {
-          context.report({
-            node: analysis.node,
-            messageId: 'inlineVariable',
-            data: { name: analysis.varName },
-            fix: fix ? createInlineFixer(sourceCode, analysis.node, analysis.usage, analysis.typeAnnotation) : null,
-          })
+          // export { xxx as yyy } パターンの場合は異なるメッセージを使用
+          if (analysis.isExportSpecifier) {
+            // ExportSpecifierからエクスポート名を取得
+            let exportedName = analysis.varName
+            let current = analysis.usage.parent
+            while (current && current.type !== 'ExportSpecifier') {
+              current = current.parent
+            }
+            if (current && current.type === 'ExportSpecifier' && current.exported) {
+              exportedName = current.exported.name
+            }
+
+            context.report({
+              node: analysis.node,
+              messageId: 'exportDirectly',
+              data: {
+                name: analysis.varName,
+                exportedName,
+              },
+              fix: fix ? createInlineFixer(sourceCode, analysis.node, analysis.usage, analysis.typeAnnotation) : null,
+            })
+          } else {
+            context.report({
+              node: analysis.node,
+              messageId: 'inlineVariable',
+              data: { name: analysis.varName },
+              fix: fix ? createInlineFixer(sourceCode, analysis.node, analysis.usage, analysis.typeAnnotation) : null,
+            })
+          }
         }
       },
     }

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable/index.js
@@ -203,7 +203,11 @@ function getVariableUsagesInScope(sourceCode, varName, declarationNode) {
 
     // 変数名が一致するIdentifierを収集（宣言自体と初期化式内は除外）
     if (isTargetIdentifier(node)) {
-      usages.push(node)
+      // 同じノードオブジェクトを重複してカウントしないようにする
+      // (export { foo } の場合、localとexportedが同じノードを指すため)
+      if (!usages.includes(node)) {
+        usages.push(node)
+      }
       return
     }
 

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -106,6 +106,13 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         }
       `,
     },
+    // React Hooks除外（一度しか使用されていない場合でも、export { xxx as yyy } パターンでなければ除外）
+    {
+      code: `
+        const data = useFormContext()
+        console.log(data)
+      `,
+    },
     // await式除外
     {
       code: `
@@ -1132,7 +1139,7 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         },
       ],
     },
-    // export { xxx as yyy } パターン（React Hooks呼び出しの場合もエラーになる）
+    // export { xxx as yyy } パターン（React Hooks呼び出しの場合でも除外されずエラーになる）
     {
       code: `
         const _useFormContext = useFormContext()

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -1106,5 +1106,44 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         },
       ],
     },
+    // export { xxx as yyy } パターン（単純な値の場合はエラーになる）
+    {
+      code: `
+        const _foo = 123
+        export { _foo as foo }
+      `,
+      errors: [
+        {
+          messageId: 'exportDirectly',
+          data: { name: '_foo', exportedName: 'foo' },
+        },
+      ],
+    },
+    // export { xxx as yyy } パターン（関数値の参照の場合はエラーになる）
+    {
+      code: `
+        const _useFormContext = useFormContext
+        export { _useFormContext as useFormContext }
+      `,
+      errors: [
+        {
+          messageId: 'exportDirectly',
+          data: { name: '_useFormContext', exportedName: 'useFormContext' },
+        },
+      ],
+    },
+    // export { xxx as yyy } パターン（React Hooks呼び出しの場合もエラーになる）
+    {
+      code: `
+        const _useFormContext = useFormContext()
+        export { _useFormContext as useFormContext }
+      `,
+      errors: [
+        {
+          messageId: 'exportDirectly',
+          data: { name: '_useFormContext', exportedName: 'useFormContext' },
+        },
+      ],
+    },
   ],
 })

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-no-unnecessary-variable.js
@@ -1145,5 +1145,18 @@ ruleTester.run('best-practice-for-no-unnecessary-variable', rule, {
         },
       ],
     },
+    // export { xxx } パターン（asなし）
+    {
+      code: `
+        const useFormContext = hoge
+        export { useFormContext }
+      `,
+      errors: [
+        {
+          messageId: 'exportDirectly',
+          data: { name: 'useFormContext', exportedName: 'useFormContext' },
+        },
+      ],
+    },
   ],
 })


### PR DESCRIPTION
## Summary
- `export { _foo as foo }` パターンの場合、より適切なエラーメッセージを表示
- React Hooks呼び出しでも `export { xxx as yyy }` パターンの場合はエラーを出すように修正

## 変更内容

### エラーメッセージの改善
従来: 「変数"_foo"は一度しか使用されていません。直接使用してください。」
改善後: 「変数"_foo"は一度しか使用されていません。export const foo = ... の形式で直接エクスポートしてください。」

### React Hooks除外ルールの調整
- 従来: React Hooks呼び出し（`useXxx()`）は常に除外
- 改善後: `export { xxx as yyy }` パターンの場合は除外しない

### 実装の詳細
- `isInExportSpecifier()` 関数を追加してExportSpecifier内での使用を検出
- `isReactHookCall()` 関数でReact Hooks呼び出しを判定
- `analyzeVariable()` 内でExportSpecifierとReact Hooksの組み合わせを適切に処理
- `exportDirectly` メッセージを追加

## Test plan
- [x] 既存テストが全てパス
- [x] `export { _foo as foo }` パターンのテストケースを追加
- [x] React Hooks呼び出しでの `export { xxx as yyy }` パターンのテストケースを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)