### PR TITLE
feat: eslint-config-smarthrでeslint-plugin-smarthr@6.20.0に更新

### DIFF
--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -64,6 +64,7 @@ export default [
       'smarthr/best-practice-for-layouts': 'error',
       'smarthr/best-practice-for-nested-attributes-array-index': 'error',
       'smarthr/best-practice-for-no-unnecessary-variable': 'off',
+      'smarthr/best-practice-for-unstable-dependencies': 'warn', // TODO: 2026/06に導入。導入したプロダクトの数に応じてerror化を検討予定
       'smarthr/best-practice-for-optional-chaining': 'error',
       'smarthr/best-practice-for-prohibit-import-smarthr-ui-local': 'error',
       'smarthr/best-practice-for-remote-trigger-dialog': 'error',

--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-smarthr": "6.19.0",
+    "eslint-plugin-smarthr": "6.20.0",
     "globals": "^17.6.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
@@ -3100,6 +3100,9 @@ exports[`should match ESLint Configuration snapshot 1`] = `
     "smarthr/best-practice-for-unnesessary-early-return": [
       0,
     ],
+    "smarthr/best-practice-for-unstable-dependencies": [
+      1,
+    ],
     "smarthr/component-name": [
       2,
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.19.0
-        version: 6.19.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.20.0
+        version: 6.20.0(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -3826,6 +3826,11 @@ packages:
 
   eslint-plugin-smarthr@6.19.0:
     resolution: {integrity: sha512-UeXIYOyuubjjEWRqLj+MhzfbhURHVSoEM67RCA0m+yaxhRkF7PafPNexHDXRdT10hVqAdzP1RDcZrIt+DG8aXw==}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.20.0:
+    resolution: {integrity: sha512-UmcLQeAhfIdouzqzMKWKcbZ90ytpf4YUcVPWCZ1KFXMq1m0wlQDC1Vzk7quA7qvb+BIQ89qYxKqux54SL1IUfQ==}
     peerDependencies:
       eslint: ^9
 
@@ -10390,6 +10395,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.19.0(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.20.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

- eslint-config-smarthr で eslint-plugin-smarthr を 6.20.0 に更新
- best-practice-for-unstable-dependencies ルールを warn で追加

## 変更内容

### パッケージ更新

`eslint-plugin-smarthr`: `6.19.0` → `6.20.0`

### 新規ルール追加

`best-practice-for-unstable-dependencies`: React Hooks の依存配列に不安定な参照を含めることを禁止するルール

```javascript
'smarthr/best-practice-for-unstable-dependencies': 'warn', // TODO: 2026/06に導入。導入したプロダクトの数に応じてerror化を検討予定
```

デフォルトでは `children` のみを検出し、オプションで他の変数名を追加可能。

## Test plan

- [x] テストが通過することを確認
- [x] スナップショットを更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)