### PR TITLE
feat: update eslint-plugin-smarthr to 6.20.0 in oxlint-config-smarthr

### DIFF
--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -226,6 +226,7 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-layouts': 'error',
     'eslint-plugin-smarthr/best-practice-for-nested-attributes-array-index': 'error',
     'eslint-plugin-smarthr/best-practice-for-no-unnecessary-variable': 'off',
+    'eslint-plugin-smarthr/best-practice-for-unstable-dependencies': 'warn', // TODO: 2026/06に導入。導入したプロダクトの数に応じてerror化を検討予定
     'eslint-plugin-smarthr/best-practice-for-optional-chaining': 'error',
     'eslint-plugin-smarthr/best-practice-for-prohibit-import-smarthr-ui-local': 'error',
     'eslint-plugin-smarthr/best-practice-for-remote-trigger-dialog': 'error',

--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -29,7 +29,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "eslint-plugin-smarthr": "6.19.0"
+    "eslint-plugin-smarthr": "6.20.0"
   },
   "peerDependencies": {
     "oxlint": ">=1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
   packages/oxlint-config-smarthr:
     dependencies:
       eslint-plugin-smarthr:
-        specifier: 6.19.0
-        version: 6.19.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.20.0
+        version: 6.20.0(eslint@9.39.4(jiti@2.4.2))
       oxlint:
         specifier: '>=1.0.0'
         version: 1.59.0
@@ -3826,6 +3826,11 @@ packages:
 
   eslint-plugin-smarthr@6.19.0:
     resolution: {integrity: sha512-UeXIYOyuubjjEWRqLj+MhzfbhURHVSoEM67RCA0m+yaxhRkF7PafPNexHDXRdT10hVqAdzP1RDcZrIt+DG8aXw==}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.20.0:
+    resolution: {integrity: sha512-UmcLQeAhfIdouzqzMKWKcbZ90ytpf4YUcVPWCZ1KFXMq1m0wlQDC1Vzk7quA7qvb+BIQ89qYxKqux54SL1IUfQ==}
     peerDependencies:
       eslint: ^9
 
@@ -10390,6 +10395,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.19.0(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.20.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

- eslint-plugin-smarthr を 6.19.0 → 6.20.0 に更新
- `best-practice-for-unstable-dependencies` ルールを追加（warn、TODO付き）

## Test plan

- [x] テスト実行（`pnpm test`）が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)