### PR TITLE
fix: oxlint-config-smarthrのeslint-plugin-smarthrバージョンを修正

### DIFF
--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -29,7 +29,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "eslint-plugin-smarthr": "6.19.0"
+    "eslint-plugin-smarthr": "6.20.0"
   },
   "peerDependencies": {
     "oxlint": ">=1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3824,11 +3824,6 @@ packages:
     peerDependencies:
       eslint: ^9
 
-  eslint-plugin-smarthr@6.19.0:
-    resolution: {integrity: sha512-UeXIYOyuubjjEWRqLj+MhzfbhURHVSoEM67RCA0m+yaxhRkF7PafPNexHDXRdT10hVqAdzP1RDcZrIt+DG8aXw==}
-    peerDependencies:
-      eslint: ^9
-
   eslint-plugin-smarthr@6.20.0:
     resolution: {integrity: sha512-UmcLQeAhfIdouzqzMKWKcbZ90ytpf4YUcVPWCZ1KFXMq1m0wlQDC1Vzk7quA7qvb+BIQ89qYxKqux54SL1IUfQ==}
     peerDependencies:
@@ -10390,11 +10385,6 @@ snapshots:
       string.prototype.repeat: 1.0.0
 
   eslint-plugin-smarthr@6.17.0(eslint@9.39.4(jiti@2.4.2)):
-    dependencies:
-      eslint: 9.39.4(jiti@2.4.2)
-      json5: 2.2.3
-
-  eslint-plugin-smarthr@6.19.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

- oxlint-config-smarthr の eslint-plugin-smarthr を 6.19.0 → 6.20.0 に修正

## 背景

release PR #1388 で、release-please が誤って eslint-plugin-smarthr のバージョンを 6.20.0 → 6.19.0 に戻してしまった。

**問題:**
- `index.js` には `best-practice-for-unstable-dependencies` ルールが含まれている（6.20.0で追加）
- `package.json` では 6.19.0 を指定（このバージョンにはルールが存在しない）
- 結果: `pnpm install --frozen-lockfile` が失敗し、**npm公開がスキップされた**

**影響範囲:**
- GitHubリリース `oxlint-config-smarthr-v0.1.10` は作成済み
- ただし、npmには公開されていない（installで失敗したため）
- **プロダクトには影響なし**（0.1.9が使用される）

## 対応

このPRで修正し、0.1.11として正しくリリースする。

## Test plan

- [x] `pnpm test` が成功することを確認
- [x] oxlint設定が正しく読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)