### PR TITLE
chore: use HTTPS repository metadata for stylelint config

### DIFF
--- a/packages/stylelint-config-smarthr/package.json
+++ b/packages/stylelint-config-smarthr/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+git@github.com:kufu/tamatebako.git"
+    "url": "git+https://github.com/kufu/tamatebako.git"
   },
   "homepage": "https://github.com/kufu/tamatebako/tree/master/packages/stylelint-config-smarthr",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- update the stylelint-config-smarthr package repository URL to use the public HTTPS Git form
- keep the package homepage and issue tracker metadata unchanged

## Validation
- node metadata assertion for packages/stylelint-config-smarthr/package.json
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm --filter stylelint-config-smarthr test
- npm pack --dry-run --ignore-scripts --json ./packages/stylelint-config-smarthr
- git diff --check