### PR TITLE
fix(eslint-config-smarthr): use HTTPS repository metadata

### DIFF
--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+git@github.com:kufu/tamatebako.git"
+    "url": "git+https://github.com/kufu/tamatebako.git"
   },
   "keywords": [
     "eslint"


### PR DESCRIPTION
## Summary

Updates `eslint-config-smarthr` package metadata to use the public HTTPS GitHub repository URL instead of the SSH-style `git+git@github.com:kufu/tamatebako.git` URL.

This keeps the package metadata usable in environments that cannot or should not resolve SSH Git URLs, without changing runtime code, dependencies, exports, or package version.

## Validation

- `node -e "const p=require('./packages/eslint-config-smarthr/package.json'); console.log(p.repository.url); if (p.repository.url !== 'git+https://github.com/kufu/tamatebako.git') process.exit(1)"`
- `git diff --check`
- `npm pack --dry-run --json ./packages/eslint-config-smarthr`
