### PR TITLE
feat: eslint-plugin-smarthrを6.21.0に更新（eslint-config-smarthr）

### DIFF
--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -90,6 +90,7 @@ export default [
       'smarthr/require-declaration': 'off',
       'smarthr/require-export': 'off',
       'smarthr/require-i18n-text': 'warn', // TODO: 2025/11にwarn化。問題なければerrorに変更予定
+      'smarthr/require-i18n-translation-sync': 'off', // TODO: 2026/06に導入。問題なければwarn/error化を検討予定
       'smarthr/require-import': 'off',
       'smarthr/trim-props': 'error',
     }

--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-smarthr": "6.20.0",
+    "eslint-plugin-smarthr": "6.21.0",
     "globals": "^17.6.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
@@ -3151,6 +3151,9 @@ exports[`should match ESLint Configuration snapshot 1`] = `
     "smarthr/require-i18n-text": [
       1,
     ],
+    "smarthr/require-i18n-translation-sync": [
+      0,
+    ],
     "smarthr/require-import": [
       0,
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.20.0
-        version: 6.20.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.21.0
+        version: 6.21.0(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -3817,6 +3817,11 @@ packages:
 
   eslint-plugin-smarthr@6.20.0:
     resolution: {integrity: sha512-UmcLQeAhfIdouzqzMKWKcbZ90ytpf4YUcVPWCZ1KFXMq1m0wlQDC1Vzk7quA7qvb+BIQ89qYxKqux54SL1IUfQ==}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.21.0:
+    resolution: {integrity: sha512-Awj4j34hE6xyfLYXRbfUWoKG0xQdzc7UGiPwAg7awa3SHouG1wgU8x2Oc63P9bYTos6X1trKPv5x5TLKXPElyQ==}
     peerDependencies:
       eslint: ^9
 
@@ -10365,6 +10370,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.20.0(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.21.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

eslint-config-smarthrでeslint-plugin-smarthrを6.21.0に更新し、require-i18n-translation-syncルールを追加しました。

## Changes

- eslint-plugin-smarthr: 6.20.0 → 6.21.0
- require-i18n-translation-syncルールを追加（初期値: off）
- TODO: 2026/06に導入。問題なければwarn/error化を検討予定

## Test plan

- [x] スナップショットテストが通ること
- [ ] CIが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)