### PR TITLE
feat: eslint-plugin-smarthrを6.21.0に更新（oxlint-config-smarthr）

### DIFF
--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -252,6 +252,7 @@ const config = {
     'eslint-plugin-smarthr/require-declaration': 'off',
     'eslint-plugin-smarthr/require-export': 'off',
     'eslint-plugin-smarthr/require-i18n-text': 'warn',
+    'eslint-plugin-smarthr/require-i18n-translation-sync': 'off', // TODO: 2026/06に導入。問題なければwarn/error化を検討予定
     'eslint-plugin-smarthr/require-import': 'off',
     'eslint-plugin-smarthr/trim-props': 'error',
   },

--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -29,7 +29,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "eslint-plugin-smarthr": "6.20.0"
+    "eslint-plugin-smarthr": "6.21.0"
   },
   "peerDependencies": {
     "oxlint": ">=1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
   packages/oxlint-config-smarthr:
     dependencies:
       eslint-plugin-smarthr:
-        specifier: 6.20.0
-        version: 6.20.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.21.0
+        version: 6.21.0(eslint@9.39.4(jiti@2.4.2))
       oxlint:
         specifier: '>=1.0.0'
         version: 1.59.0
@@ -3817,6 +3817,11 @@ packages:
 
   eslint-plugin-smarthr@6.20.0:
     resolution: {integrity: sha512-UmcLQeAhfIdouzqzMKWKcbZ90ytpf4YUcVPWCZ1KFXMq1m0wlQDC1Vzk7quA7qvb+BIQ89qYxKqux54SL1IUfQ==}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.21.0:
+    resolution: {integrity: sha512-Awj4j34hE6xyfLYXRbfUWoKG0xQdzc7UGiPwAg7awa3SHouG1wgU8x2Oc63P9bYTos6X1trKPv5x5TLKXPElyQ==}
     peerDependencies:
       eslint: ^9
 
@@ -10365,6 +10370,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.20.0(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.21.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

oxlint-config-smarthrでeslint-plugin-smarthrを6.21.0に更新し、require-i18n-translation-syncルールを追加しました。

## Changes

- eslint-plugin-smarthr: 6.20.0 → 6.21.0
- require-i18n-translation-syncルールを追加（初期値: off）
- TODO: 2026/06に導入。問題なければwarn/error化を検討予定

## Test plan

- [x] テストが通ること
- [ ] CIが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)