### PR TITLE
fix: oxlint-config-smarthrのrepository URLをHTTPS形式に変更

### DIFF
--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -29,7 +29,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "eslint-plugin-smarthr": "6.20.0"
+    "eslint-plugin-smarthr": "6.21.0"
   },
   "peerDependencies": {
     "oxlint": ">=1.0.0"

--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+git@github.com:kufu/tamatebako.git",
+    "url": "git+https://github.com/kufu/tamatebako.git",
     "directory": "packages/oxlint-config-smarthr"
   },
   "scripts": {

--- a/packages/stylelint-config-smarthr/package.json
+++ b/packages/stylelint-config-smarthr/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kufu/tamatebako.git"
+    "url": "git+git@github.com:kufu/tamatebako.git"
   },
   "homepage": "https://github.com/kufu/tamatebako/tree/master/packages/stylelint-config-smarthr",
   "publishConfig": {

--- a/packages/stylelint-config-smarthr/package.json
+++ b/packages/stylelint-config-smarthr/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+git@github.com:kufu/tamatebako.git"
+    "url": "git+https://github.com/kufu/tamatebako.git"
   },
   "homepage": "https://github.com/kufu/tamatebako/tree/master/packages/stylelint-config-smarthr",
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
   packages/oxlint-config-smarthr:
     dependencies:
       eslint-plugin-smarthr:
-        specifier: 6.21.0
-        version: 6.21.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.20.0
+        version: 6.20.0(eslint@9.39.4(jiti@2.4.2))
       oxlint:
         specifier: '>=1.0.0'
         version: 1.59.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
   packages/oxlint-config-smarthr:
     dependencies:
       eslint-plugin-smarthr:
-        specifier: 6.20.0
-        version: 6.20.0(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.21.0
+        version: 6.21.0(eslint@9.39.4(jiti@2.4.2))
       oxlint:
         specifier: '>=1.0.0'
         version: 1.59.0
@@ -3812,11 +3812,6 @@ packages:
 
   eslint-plugin-smarthr@6.18.0:
     resolution: {integrity: sha512-0vNKLSjpkTO4zH7C93RYiLKPzpxLJjlV8NZRDgSEKSBB8MJzNa26Vbe7G6HDdeY2d94KMwRDdkVA8Fjo7yrLGQ==}
-    peerDependencies:
-      eslint: ^9
-
-  eslint-plugin-smarthr@6.20.0:
-    resolution: {integrity: sha512-UmcLQeAhfIdouzqzMKWKcbZ90ytpf4YUcVPWCZ1KFXMq1m0wlQDC1Vzk7quA7qvb+BIQ89qYxKqux54SL1IUfQ==}
     peerDependencies:
       eslint: ^9
 
@@ -10365,11 +10360,6 @@ snapshots:
       string.prototype.repeat: 1.0.0
 
   eslint-plugin-smarthr@6.18.0(eslint@9.39.4(jiti@2.4.2)):
-    dependencies:
-      eslint: 9.39.4(jiti@2.4.2)
-      json5: 2.2.3
-
-  eslint-plugin-smarthr@6.20.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

oxlint-config-smarthrのrepository.urlをHTTPS形式に統一しました。

stylelint-config-smarthrは既にPR #1400で対応済みのため、このPRではoxlintのみを対象としています。

## Changes

- oxlint-config-smarthr: `git+git@github.com:kufu/tamatebako.git` → `git+https://github.com/kufu/tamatebako.git`

## Related PRs

- #1400 (stylelint-config-smarthr) - 既に対応済み
- #1403 (eslint-config-smarthr) - マージ済み
- #1407 (eslint-plugin-smarthr) - マージ済み

## Test plan

- [x] 変更内容を確認
- [x] pnpm-lock.yamlを更新
- [ ] CIが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)