### PR TITLE
fix: require-i18n-translation-syncでsatisfies演算子に対応

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/require-i18n-translation-sync/README.md
+++ b/packages/eslint-plugin-smarthr/rules/require-i18n-translation-sync/README.md
@@ -200,6 +200,25 @@ export const translations = {
 } as const
 ```
 
+### satisfies演算子
+
+```typescript
+// satisfies のみ
+export const translations = {
+  'Common/Button/Submit': '送信'
+} satisfies Record<string, string>
+
+// as const と satisfies の併用
+export const translations = {
+  'Common/Button/Submit': '送信'
+} as const satisfies Record<string, string>
+
+// satisfies と as const の併用（順序逆）
+export const translations = {
+  'Common/Button/Submit': '送信'
+} satisfies Record<string, string> as const
+```
+
 ### 型注釈
 
 ```typescript

--- a/packages/eslint-plugin-smarthr/rules/require-i18n-translation-sync/index.js
+++ b/packages/eslint-plugin-smarthr/rules/require-i18n-translation-sync/index.js
@@ -126,6 +126,18 @@ function findExportedObject(program) {
                 exportedObject = decl.init.expression
               }
               break
+            case 'TSSatisfiesExpression':
+              if (decl.init.expression.type === 'ObjectExpression') {
+                // satisfies Type
+                objectExportCount++
+                exportedObject = decl.init.expression
+              } else if (decl.init.expression.type === 'TSAsExpression' &&
+                         decl.init.expression.expression.type === 'ObjectExpression') {
+                // as const satisfies Type のパターン
+                objectExportCount++
+                exportedObject = decl.init.expression.expression
+              }
+              break
           }
         }
       }
@@ -142,6 +154,18 @@ function findExportedObject(program) {
           if (node.declaration.expression.type === 'ObjectExpression') {
             objectExportCount++
             exportedObject = node.declaration.expression
+          }
+          break
+        case 'TSSatisfiesExpression':
+          if (node.declaration.expression.type === 'ObjectExpression') {
+            // satisfies Type
+            objectExportCount++
+            exportedObject = node.declaration.expression
+          } else if (node.declaration.expression.type === 'TSAsExpression' &&
+                     node.declaration.expression.expression.type === 'ObjectExpression') {
+            // as const satisfies Type のパターン
+            objectExportCount++
+            exportedObject = node.declaration.expression.expression
           }
           break
       }

--- a/packages/eslint-plugin-smarthr/test/require-i18n-translation-sync.js
+++ b/packages/eslint-plugin-smarthr/test/require-i18n-translation-sync.js
@@ -201,6 +201,41 @@ ruleTester.run('require-i18n-translation-sync', rule, {
       filename: setupTestFile('valid-with-multiple-types.ts', { key1: 'value1' }),
       options: defaultOptions,
     },
+
+    // as const satisfies パターン
+    {
+      code: "export const translations = { key1: 'value1' } as const satisfies Record<string, string>",
+      filename: setupTestFile('valid-as-const-satisfies.ts', { key1: 'value1' }),
+      options: defaultOptions,
+    },
+
+    // satisfies as const パターン
+    {
+      code: "export const translations = { key1: 'value1' } satisfies Record<string, string> as const",
+      filename: setupTestFile('valid-satisfies-as-const.ts', { key1: 'value1' }),
+      options: defaultOptions,
+    },
+
+    // satisfies のみのパターン
+    {
+      code: "export const translations = { key1: 'value1' } satisfies Record<string, string>",
+      filename: setupTestFile('valid-satisfies-only.ts', { key1: 'value1' }),
+      options: defaultOptions,
+    },
+
+    // export default with satisfies
+    {
+      code: "export default { key1: 'value1' } satisfies Record<string, string>",
+      filename: setupTestFile('valid-default-satisfies.ts', { key1: 'value1' }),
+      options: defaultOptions,
+    },
+
+    // export default with as const satisfies
+    {
+      code: "export default { key1: 'value1' } as const satisfies Record<string, string>",
+      filename: setupTestFile('valid-default-as-const-satisfies.ts', { key1: 'value1' }),
+      options: defaultOptions,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
## Summary

require-i18n-translation-syncルールでTypeScriptの`satisfies`演算子に対応しました。

## 問題

TSSatisfiesExpression（TypeScriptのsatisfies演算子）に対応していないため、以下のような構文でエラーが発生していました：

```typescript
export const locale = {
  // ...
} as const satisfies Record<keyof typeof ja, string>
```

## 修正内容

`findExportedObject`関数に`TSSatisfiesExpression`のケースを追加し、以下のパターンに対応：

```typescript
// satisfies のみ
export const translations = { ... } satisfies Record<string, string>

// as const satisfies
export const translations = { ... } as const satisfies Record<string, string>

// satisfies as const
export const translations = { ... } satisfies Record<string, string> as const

// export default with satisfies
export default { ... } satisfies Record<string, string>
export default { ... } as const satisfies Record<string, string>
```

## 変更箇所

- `packages/eslint-plugin-smarthr/rules/require-i18n-translation-sync/index.js`
  - ExportNamedDeclarationにTSSatisfiesExpressionケースを追加
  - ExportDefaultDeclarationにTSSatisfiesExpressionケースを追加
- `packages/eslint-plugin-smarthr/test/require-i18n-translation-sync.js`
  - satisfies関連のテストケースを5つ追加
- `packages/eslint-plugin-smarthr/rules/require-i18n-translation-sync/README.md`
  - satisfies演算子のセクションを追加

## Test plan

- [x] 単体テスト通過（39個のテストケース）
- [ ] CIが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)