### PR TITLE
feat: best-practice-for-unstable-dependenciesに正規表現パターンとカスタムメッセージを追加

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-unstable-dependencies/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-unstable-dependencies/README.md
@@ -326,10 +326,6 @@ useEffect(() => {
       {
         "pattern": "/^on[A-Z]/",
         "message": "イベントハンドラーは依存配列に含めないでください。"
-      },
-      {
-        "pattern": "icon",
-        "message": "iconはReactNodeのため不安定です。"
       }
     ]
   }]
@@ -347,23 +343,6 @@ useEffect(() => {
   onClick()
 }, [onClick])
 // エラー: 依存配列に不安定な参照と予想される"onClick"が含まれています。イベントハンドラーは依存配列に含めないでください。
-```
-
-**複数形式の混在も可能:**
-
-```javascript
-{
-  "smarthr/best-practice-for-unstable-dependencies": ["error", {
-    "additionalUnstableNames": [
-      "icon",      // 文字列（完全一致）
-      "/Ref$/",    // 正規表現
-      {            // オブジェクト（カスタムメッセージ）
-        "pattern": "/^on[A-Z]/",
-        "message": "イベントハンドラーは依存配列に含めないでください。"
-      }
-    ]
-  }]
-}
 ```
 
 ### additionalTargetHooks

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-unstable-dependencies/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-unstable-dependencies/README.md
@@ -263,10 +263,105 @@ const handleClick = useCallback((e) => {
 
 デフォルトでは `children` のみをチェックしますが、他の変数名を追加できます。
 
+#### 文字列形式（完全一致）
+
 ```javascript
 {
   "smarthr/best-practice-for-unstable-dependencies": ["error", {
     "additionalUnstableNames": ["icon", "prefix", "object", "items", "callback"]
+  }]
+}
+```
+
+#### 正規表現パターン
+
+`/pattern/` のように先頭と末尾を `/` で囲むと、正規表現パターンとして扱われます。
+
+**例1: Refで終わる変数を検出**
+
+```javascript
+{
+  "smarthr/best-practice-for-unstable-dependencies": ["error", {
+    "additionalUnstableNames": ["/Ref$/"]
+  }]
+}
+```
+
+```javascript
+// ❌ NG
+useEffect(() => {
+  console.log(inputRef.current)
+}, [inputRef])  // "inputRef"はパターン/Ref$/にマッチ
+```
+
+**例2: onで始まる変数（イベントハンドラー）を検出**
+
+```javascript
+{
+  "smarthr/best-practice-for-unstable-dependencies": ["error", {
+    "additionalUnstableNames": ["/^on[A-Z]/"]
+  }]
+}
+```
+
+```javascript
+// ❌ NG
+useEffect(() => {
+  onClick()
+}, [onClick])  // "onClick"はパターン/^on[A-Z]/にマッチ
+```
+
+#### オブジェクト形式（カスタムメッセージ付き）
+
+特定のパターンに対して独自のエラーメッセージを設定できます。
+
+```javascript
+{
+  "smarthr/best-practice-for-unstable-dependencies": ["error", {
+    "additionalUnstableNames": [
+      {
+        "pattern": "/Ref$/",
+        "message": "Refは再レンダリングをトリガーしません。"
+      },
+      {
+        "pattern": "/^on[A-Z]/",
+        "message": "イベントハンドラーは依存配列に含めないでください。"
+      },
+      {
+        "pattern": "icon",
+        "message": "iconはReactNodeのため不安定です。"
+      }
+    ]
+  }]
+}
+```
+
+```javascript
+// ❌ NG
+useEffect(() => {
+  console.log(inputRef.current)
+}, [inputRef])
+// エラー: 依存配列に不安定な参照と予想される"inputRef"が含まれています。Refは再レンダリングをトリガーしません。
+
+useEffect(() => {
+  onClick()
+}, [onClick])
+// エラー: 依存配列に不安定な参照と予想される"onClick"が含まれています。イベントハンドラーは依存配列に含めないでください。
+```
+
+**複数形式の混在も可能:**
+
+```javascript
+{
+  "smarthr/best-practice-for-unstable-dependencies": ["error", {
+    "additionalUnstableNames": [
+      "icon",      // 文字列（完全一致）
+      "/Ref$/",    // 正規表現
+      {            // オブジェクト（カスタムメッセージ）
+        "pattern": "/^on[A-Z]/",
+        "message": "イベントハンドラーは依存配列に含めないでください。"
+      }
+    ]
   }]
 }
 ```

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-unstable-dependencies/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-unstable-dependencies/index.js
@@ -4,7 +4,20 @@ const SCHEMA = [
     properties: {
       additionalUnstableNames: {
         type: 'array',
-        items: { type: 'string' },
+        items: {
+          oneOf: [
+            { type: 'string' },
+            {
+              type: 'object',
+              properties: {
+                pattern: { type: 'string' },
+                message: { type: 'string' },
+              },
+              required: ['pattern'],
+              additionalProperties: false,
+            },
+          ],
+        },
         default: [],
       },
       additionalTargetHooks: {
@@ -23,6 +36,41 @@ const DEFAULT_TARGET_HOOKS = ['useEffect', 'useLayoutEffect', 'useCallback', 'us
 
 const DETAIL_LINK = `
  - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-unstable-dependencies`
+
+/**
+ * 文字列またはオブジェクト形式の設定をパースする
+ * @param {Array<string | {pattern: string, message?: string}>} names - 名前の配列
+ * @returns {Array<{pattern: string, message: string | null}>}
+ */
+function parseUnstableNames(names) {
+  return names.map(name => {
+    if (typeof name === 'string') {
+      return { pattern: name, message: null }
+    } else {
+      return { pattern: name.pattern, message: name.message || null }
+    }
+  })
+}
+
+/**
+ * パースされた設定からマッチャーを構築する
+ * @param {Array<{pattern: string, message: string | null}>} parsedNames - パース済み設定
+ * @returns {Array<{regex: RegExp, message: string | null, pattern: string}>}
+ */
+function buildPatternMatchers(parsedNames) {
+  return parsedNames.map(({ pattern, message }) => {
+    let regex
+    if (pattern.startsWith('/') && pattern.endsWith('/') && pattern.length > 2) {
+      // 正規表現パターン: /pattern/ → pattern
+      regex = new RegExp(pattern.slice(1, -1))
+    } else {
+      // 完全一致パターン: name → ^name$
+      regex = new RegExp(`^${pattern.replace(DOLLAR_SIGN_REGEX, '\\$')}$`)
+    }
+
+    return { regex, message, pattern }
+  })
+}
 
 /**
  * 名前の配列から正規表現を生成する（$をエスケープして処理）
@@ -67,14 +115,17 @@ module.exports = {
     schema: SCHEMA,
     messages: {
       unstableDependency: '依存配列に不安定な参照と予想される"{{name}}"が含まれています。オブジェクトやReactNodeなどの参照は頻繁に変わるため、不要な再実行や無限ループの原因となります。{{detailLink}}',
+      customUnstableDependency: '依存配列に不安定な参照と予想される"{{name}}"が含まれています。{{message}}{{detailLink}}',
     },
   },
   create(context) {
     const options = context.options[0] || {}
-    const unstableNames = [...DEFAULT_UNSTABLE_NAMES, ...(options.additionalUnstableNames || [])]
+    const additionalUnstableNames = options.additionalUnstableNames || []
     const targetHooks = [...DEFAULT_TARGET_HOOKS, ...(options.additionalTargetHooks || [])]
 
-    const unstableNamesRegex = buildRegex(unstableNames)
+    // パターンマッチャーを構築
+    const parsedUnstableNames = parseUnstableNames([...DEFAULT_UNSTABLE_NAMES, ...additionalUnstableNames])
+    const unstableNameMatchers = buildPatternMatchers(parsedUnstableNames)
     const targetHooksRegex = buildRegex(targetHooks)
 
     return {
@@ -98,15 +149,20 @@ module.exports = {
 
         // 不安定な参照と予想される名前が含まれているかチェック
         for (const identifier of identifiers) {
-          if (unstableNamesRegex.test(identifier.name)) {
-            context.report({
-              node: identifier.node,
-              messageId: 'unstableDependency',
-              data: {
-                name: identifier.name,
-                detailLink: DETAIL_LINK,
-              },
-            })
+          // パターンマッチャーで順番にチェック
+          for (const matcher of unstableNameMatchers) {
+            if (matcher.regex.test(identifier.name)) {
+              context.report({
+                node: identifier.node,
+                messageId: matcher.message ? 'customUnstableDependency' : 'unstableDependency',
+                data: {
+                  name: identifier.name,
+                  message: matcher.message || '',
+                  detailLink: DETAIL_LINK,
+                },
+              })
+              break // 最初にマッチしたパターンで報告して終了
+            }
           }
         }
       },

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-unstable-dependencies/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-unstable-dependencies/index.js
@@ -46,9 +46,8 @@ function parseUnstableNames(names) {
   return names.map(name => {
     if (typeof name === 'string') {
       return { pattern: name, message: null }
-    } else {
-      return { pattern: name.pattern, message: name.message || null }
     }
+    return { pattern: name.pattern, message: name.message || null }
   })
 }
 
@@ -59,14 +58,11 @@ function parseUnstableNames(names) {
  */
 function buildPatternMatchers(parsedNames) {
   return parsedNames.map(({ pattern, message }) => {
-    let regex
-    if (pattern.startsWith('/') && pattern.endsWith('/') && pattern.length > 2) {
-      // 正規表現パターン: /pattern/ → pattern
-      regex = new RegExp(pattern.slice(1, -1))
-    } else {
-      // 完全一致パターン: name → ^name$
-      regex = new RegExp(`^${pattern.replace(DOLLAR_SIGN_REGEX, '\\$')}$`)
-    }
+    const regexPattern = pattern.startsWith('/') && pattern.endsWith('/') && pattern.length > 2
+      ? pattern.slice(1, -1)  // 正規表現パターン: /pattern/ → pattern
+      : `^${pattern.replace(DOLLAR_SIGN_REGEX, '\\$')}$`  // 完全一致パターン: name → ^name$
+
+    const regex = new RegExp(regexPattern)
 
     return { regex, message, pattern }
   })

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-unstable-dependencies.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-unstable-dependencies.js
@@ -84,6 +84,33 @@ ruleTester.run('best-practice-for-unstable-dependencies', rule, {
       `,
       options: [{ additionalTargetHooks: ['useCustom'] }],
     },
+    // 正規表現パターン: Refで終わらない変数
+    {
+      code: `
+        useEffect(() => {
+          console.log(reference)
+        }, [reference])
+      `,
+      options: [{ additionalUnstableNames: ['/Ref$/'] }],
+    },
+    // 正規表現パターン: onで始まらない変数
+    {
+      code: `
+        useEffect(() => {
+          console.log(handler)
+        }, [handler])
+      `,
+      options: [{ additionalUnstableNames: ['/^on[A-Z]/'] }],
+    },
+    // オブジェクト形式: パターンにマッチしない
+    {
+      code: `
+        useEffect(() => {
+          console.log(value)
+        }, [value])
+      `,
+      options: [{ additionalUnstableNames: [{ pattern: '/Ref$/', message: 'Refは再レンダリングをトリガーしません。' }] }],
+    },
   ],
   invalid: [
     // useEffect with children
@@ -277,6 +304,119 @@ ruleTester.run('best-practice-for-unstable-dependencies', rule, {
         {
           messageId: 'unstableDependency',
           data: { name: 'icon', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // 正規表現パターン: Refで終わる変数を検出
+    {
+      code: `
+        useEffect(() => {
+          console.log(inputRef.current)
+        }, [inputRef])
+      `,
+      options: [{ additionalUnstableNames: ['/Ref$/'] }],
+      errors: [
+        {
+          messageId: 'unstableDependency',
+          data: { name: 'inputRef', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // 正規表現パターン: onで始まる変数（イベントハンドラ）を検出
+    {
+      code: `
+        useEffect(() => {
+          onClick()
+        }, [onClick])
+      `,
+      options: [{ additionalUnstableNames: ['/^on[A-Z]/'] }],
+      errors: [
+        {
+          messageId: 'unstableDependency',
+          data: { name: 'onClick', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // 正規表現パターン: 複数のパターンを指定
+    {
+      code: `
+        useEffect(() => {
+          console.log(buttonRef, onChange)
+        }, [buttonRef, onChange])
+      `,
+      options: [{ additionalUnstableNames: ['/Ref$/', '/^on[A-Z]/'] }],
+      errors: [
+        {
+          messageId: 'unstableDependency',
+          data: { name: 'buttonRef', detailLink: DETAIL_LINK },
+        },
+        {
+          messageId: 'unstableDependency',
+          data: { name: 'onChange', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // オブジェクト形式: カスタムメッセージを指定
+    {
+      code: `
+        useEffect(() => {
+          console.log(inputRef.current)
+        }, [inputRef])
+      `,
+      options: [{ additionalUnstableNames: [{ pattern: '/Ref$/', message: 'Refは再レンダリングをトリガーしません。' }] }],
+      errors: [
+        {
+          messageId: 'customUnstableDependency',
+          data: { name: 'inputRef', message: 'Refは再レンダリングをトリガーしません。', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // オブジェクト形式: 完全一致パターンでカスタムメッセージ
+    {
+      code: `
+        useEffect(() => {
+          console.log(icon)
+        }, [icon])
+      `,
+      options: [{ additionalUnstableNames: [{ pattern: 'icon', message: 'iconはReactNodeのため不安定です。' }] }],
+      errors: [
+        {
+          messageId: 'customUnstableDependency',
+          data: { name: 'icon', message: 'iconはReactNodeのため不安定です。', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // 文字列とオブジェクト形式の混在
+    {
+      code: `
+        useEffect(() => {
+          console.log(children, onClick)
+        }, [children, onClick])
+      `,
+      options: [{ additionalUnstableNames: ['children', { pattern: '/^on[A-Z]/', message: 'イベントハンドラーは依存配列に含めないでください。' }] }],
+      errors: [
+        {
+          messageId: 'unstableDependency',
+          data: { name: 'children', detailLink: DETAIL_LINK },
+        },
+        {
+          messageId: 'customUnstableDependency',
+          data: { name: 'onClick', message: 'イベントハンドラーは依存配列に含めないでください。', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // 正規表現パターン: ドル記号のエスケープを確認
+    {
+      code: `
+        useEffect(() => {
+          console.log(price$)
+        }, [price$])
+      `,
+      options: [{ additionalUnstableNames: ['price$'] }],
+      errors: [
+        {
+          messageId: 'unstableDependency',
+          data: { name: 'price$', detailLink: DETAIL_LINK },
         },
       ],
     },

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-unstable-dependencies.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-unstable-dependencies.js
@@ -371,21 +371,6 @@ ruleTester.run('best-practice-for-unstable-dependencies', rule, {
         },
       ],
     },
-    // オブジェクト形式: 完全一致パターンでカスタムメッセージ
-    {
-      code: `
-        useEffect(() => {
-          console.log(icon)
-        }, [icon])
-      `,
-      options: [{ additionalUnstableNames: [{ pattern: 'icon', message: 'iconはReactNodeのため不安定です。' }] }],
-      errors: [
-        {
-          messageId: 'customUnstableDependency',
-          data: { name: 'icon', message: 'iconはReactNodeのため不安定です。', detailLink: DETAIL_LINK },
-        },
-      ],
-    },
     // 文字列とオブジェクト形式の混在
     {
       code: `

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-unstable-dependencies.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-unstable-dependencies.js
@@ -375,14 +375,14 @@ ruleTester.run('best-practice-for-unstable-dependencies', rule, {
     {
       code: `
         useEffect(() => {
-          console.log(children, onClick)
-        }, [children, onClick])
+          console.log(icon, onClick)
+        }, [icon, onClick])
       `,
-      options: [{ additionalUnstableNames: ['children', { pattern: '/^on[A-Z]/', message: 'イベントハンドラーは依存配列に含めないでください。' }] }],
+      options: [{ additionalUnstableNames: ['icon', { pattern: '/^on[A-Z]/', message: 'イベントハンドラーは依存配列に含めないでください。' }] }],
       errors: [
         {
           messageId: 'unstableDependency',
-          data: { name: 'children', detailLink: DETAIL_LINK },
+          data: { name: 'icon', detailLink: DETAIL_LINK },
         },
         {
           messageId: 'customUnstableDependency',


### PR DESCRIPTION
## Summary

`best-practice-for-unstable-dependencies` ルールの `additionalUnstableNames` オプションに以下の機能を追加しました:

- **正規表現パターン**: `/pattern/` 形式で正規表現による変数名マッチング
- **カスタムエラーメッセージ**: オブジェクト形式 `{pattern, message}` で独自のエラーメッセージを設定

## 主な変更点

### 対応形式

1. **文字列（完全一致）** - 既存の動作
   ```javascript
   "additionalUnstableNames": ["icon", "prefix"]
   ```

2. **正規表現パターン**
   ```javascript
   "additionalUnstableNames": ["/Ref$/", "/^on[A-Z]/"]
   ```
   - `/Ref$/`: Refで終わる変数を検出（`inputRef`, `buttonRef`など）
   - `/^on[A-Z]/`: onで始まる変数を検出（`onClick`, `onChange`など）

3. **カスタムメッセージ付き**
   ```javascript
   "additionalUnstableNames": [
     {
       "pattern": "/Ref$/",
       "message": "Refは再レンダリングをトリガーしません。"
     }
   ]
   ```

### 実装内容

- `parseUnstableNames()`: 文字列/オブジェクト形式を正規化
- `buildPatternMatchers()`: パターンごとに正規表現とメッセージを構築
- スキーマ: `oneOf`で文字列とオブジェクト形式の両方をサポート
- メッセージ: `customUnstableDependency` を追加

## Test plan

- [x] 正規表現パターンのテスト（`/Ref$/`, `/^on[A-Z]/`）
- [x] カスタムメッセージのテスト
- [x] 文字列とオブジェクト形式の混在
- [x] ドル記号のエスケープ確認
- [x] 既存テストが全てパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)