### PR TITLE
fix(wareki): warekiToDateで「元年」を解釈できるようにする

### DIFF
--- a/packages/wareki/src/__tests__/index.test.ts
+++ b/packages/wareki/src/__tests__/index.test.ts
@@ -265,5 +265,33 @@ describe('wareki', () => {
         formatted: '1999:12:31',
       })
     })
+
+    it('parse a date string whose year is 元年 (the first year of an era)', () => {
+      expect(warekiToDate('令和元年5月1日')).toEqual({
+        isValid: true,
+        result: new Date(2019, 5 - 1, 1),
+        formatted: '令和元年5月1日',
+      })
+      expect(warekiToDate('平成元年1月8日')).toEqual({
+        isValid: true,
+        result: new Date(1989, 1 - 1, 8),
+        formatted: '平成元年1月8日',
+      })
+      expect(warekiToDate('昭和元年12月25日')).toEqual({
+        isValid: true,
+        result: new Date(1926, 12 - 1, 25),
+        formatted: '昭和元年12月25日',
+      })
+      expect(warekiToDate('大正元年7月30日')).toEqual({
+        isValid: true,
+        result: new Date(1912, 7 - 1, 30),
+        formatted: '大正元年7月30日',
+      })
+      expect(warekiToDate('明治元年1月25日')).toEqual({
+        isValid: true,
+        result: new Date(1868, 1 - 1, 25),
+        formatted: '明治元年1月25日',
+      })
+    })
   })
 })

--- a/packages/wareki/src/index.ts
+++ b/packages/wareki/src/index.ts
@@ -42,7 +42,7 @@ const { WAREKI_START_YEARS, reg, selectGengo } = (() => {
     reg: {
       dateString: new RegExp(`^([0-9]{4})(${SEPARATOR})?([0-9]{1,2})(${SEPARATOR})?([0-9]{1,2})([\\s．]([0-9]{2}):([0-9]{2})$)?`),
       wareki: new RegExp(
-        `^(${Object.keys(YEARS).join('|')})([0-9]{1,2})(${SEPARATOR})([0-9]{1,2})(${SEPARATOR})([0-9]{1,2})(${SEPARATOR}?)$`,
+        `^(${Object.keys(YEARS).join('|')})(元|[0-9]{1,2})(${SEPARATOR})([0-9]{1,2})(${SEPARATOR})([0-9]{1,2})(${SEPARATOR}?)$`,
       ),
     },
     selectGengo: (year: number, month: number, date: number): Geongo => {
@@ -107,11 +107,13 @@ export function warekiToDate(wareki: string): Result<Date> {
 
   if (matchedWareki) {
     const baseYear = WAREKI_START_YEARS[matchedWareki[1] as keyof typeof WAREKI_START_YEARS]
+    // 「元年」は和暦1年なので 1 として扱う
+    const warekiYear = matchedWareki[2] === '元' ? 1 : Number(matchedWareki[2])
 
     return {
       isValid: true,
       // 和暦は1年から始まるので - 1 が必要
-      result: new Date(baseYear + Number(matchedWareki[2]) - 1, Number(matchedWareki[4]) - 1, Number(matchedWareki[6])),
+      result: new Date(baseYear + warekiYear - 1, Number(matchedWareki[4]) - 1, Number(matchedWareki[6])),
       formatted,
     }
   }


### PR DESCRIPTION
## 内容

`dateToWareki` は各元号の1年目を「元年」として出力します。たとえば `dateToWareki(new Date(2019, 4, 1))` は `令和元年5月1日` を返し、既存テストでもその形を確認しています。

一方で `warekiToDate` の年の正規表現は `[0-9]{1,2}` しか受け付けていないため、この「元年」を読み戻すと `isValid: false` になります。`dateToWareki` の出力をそのまま `warekiToDate` に渡すと、元号の1年目だけ相互変換が壊れる状態でした。

## 修正

- 年部分の正規表現を `(元|[0-9]{1,2})` に拡張
- 「元」が来たら和暦1年として扱う分岐を追加
- `dateToWareki` の出力と対になる形で、各元号の「元年」を解釈するテストを追加

## 確認

- wareki パッケージのテストはパスします（既存＋追加）
- 追加したテストは修正前は失敗し、修正後に通ることを確認しました
