### PR TITLE
fix: oxlint-config-smarthrのeslint-plugin-smarthrを6.21.2に修正

### DIFF
--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -29,7 +29,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "eslint-plugin-smarthr": "6.21.1"
+    "eslint-plugin-smarthr": "6.21.2"
   },
   "peerDependencies": {
     "oxlint": ">=1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3851,11 +3851,6 @@ packages:
     peerDependencies:
       eslint: ^9
 
-  eslint-plugin-smarthr@6.21.1:
-    resolution: {integrity: sha512-fFYpIMVMtmSgl8D06m4YtEJeLczVoyTscic44zX1FVkdLIokvPTENgeovGQ9gu3OZoAPexRbwtj6QO6X7sQFXw==}
-    peerDependencies:
-      eslint: ^9
-
   eslint-plugin-smarthr@6.21.2:
     resolution: {integrity: sha512-M0s/aNBx/ozaq0RyIACKdwx+gMFoW7Ivu61o7N+u/J9n0RZGCkxKQiKhDiO9DVKIkmCPWzBjLl0wUMYvaAih5A==}
     peerDependencies:
@@ -10376,11 +10371,6 @@ snapshots:
       string.prototype.repeat: 1.0.0
 
   eslint-plugin-smarthr@6.21.0(eslint@9.39.4(jiti@2.4.2)):
-    dependencies:
-      eslint: 9.39.4(jiti@2.4.2)
-      json5: 2.2.3
-
-  eslint-plugin-smarthr@6.21.1(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

release-pleaseのPR (#1433) でoxlint-config-smarthrのeslint-plugin-smarthrが6.21.1に巻き戻されていたため、6.21.2に修正しました。

## 問題の経緯

1. PR #1432で6.21.2に更新
2. PR #1433 (release-please) がマージされ、6.21.1に巻き戻り
3. 本PRで6.21.2に再修正

## 変更内容

- packages/oxlint-config-smarthr/package.json: eslint-plugin-smarthr 6.21.1 → 6.21.2

## Test plan

- [x] pnpm test 実行済み
- [x] oxlint-config-smarthrのテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)