### PR TITLE
feat: best-practice-for-function-call-consolidation ルールを追加

### DIFF
--- a/packages/eslint-plugin-smarthr/README.md
+++ b/packages/eslint-plugin-smarthr/README.md
@@ -25,6 +25,7 @@
 - [best-practice-for-data-test-attribute](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-data-test-attribute)
 - [best-practice-for-date](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-date)
 - [best-practice-for-default-props](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-default-props)
+- [best-practice-for-function-call-consolidation](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation)
 - [best-practice-for-interactive-element](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-interactive-element)
 - [best-practice-for-lazy-variable](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-lazy-variable)
 - [best-practice-for-no-unnecessary-variable](https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-no-unnecessary-variable)

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation/README.md
@@ -77,6 +77,24 @@ function Component() {
 const element = isAdmin
   ? <Container size="large"><AdminPanel /></Container>
   : <Container size="large"><UserPanel /></Container>
+
+// spread attributes
+function Component() {
+  if (condition) {
+    return <Hoge {...props}><Fuga></Fuga></Hoge>
+  } else {
+    return <Hoge {...props}><Piyo></Piyo></Hoge>
+  }
+}
+
+// spread + 通常の属性
+function Component() {
+  if (condition) {
+    return <Hoge {...props} name="test"><Fuga></Fuga></Hoge>
+  } else {
+    return <Hoge {...props} name="test"><Piyo></Piyo></Hoge>
+  }
+}
 ```
 
 ## ✅ Valid
@@ -128,6 +146,28 @@ if (condition) {
   return <ComponentA>{children}</ComponentA>
 } else {
   return <ComponentB>{children}</ComponentB>
+}
+```
+
+### JSX: spread attributesの内容が異なる場合
+
+```jsx
+// spreadの変数が異なるため、許容される
+if (condition) {
+  return <Hoge {...propsA}><Fuga></Fuga></Hoge>
+} else {
+  return <Hoge {...propsB}><Piyo></Piyo></Hoge>
+}
+```
+
+### JSX: spreadがある/ない場合
+
+```jsx
+// 属性の形式が異なるため、許容される
+if (condition) {
+  return <Hoge name="test"><Fuga></Fuga></Hoge>
+} else {
+  return <Hoge {...props}><Piyo></Piyo></Hoge>
 }
 ```
 
@@ -192,3 +232,4 @@ return (
 
 - メソッドチェーンは完全一致で検出します。例えば、`api.post('/endpoint1').send(dataA)` と `api.post('/endpoint2').send(dataB)` は検出されません（エンドポイントが異なるため）。
 - JSXの場合、コンポーネント名と属性（値を含む）が完全に一致する場合のみ検出します。子要素の違いは検出対象です。
+- JSXのspread attributes（`{...props}`）も含めて全属性を比較します。spreadの変数名が異なる場合（`{...propsA}` vs `{...propsB}`）は検出されません。

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation/README.md
@@ -1,0 +1,194 @@
+# best-practice-for-function-call-consolidation
+
+すべての分岐で同じ関数を呼び出している場合、引数のみを条件分岐にすることを推奨します。
+
+**このルールは検出のみで、自動修正は提供しません。** 修正方法は状況により異なるため、手動で対応してください。
+
+## ❌ Invalid
+
+### パターン1: if-else文で同じ関数を呼び出す
+
+```javascript
+// 基本的なif-else
+if (condition) {
+  func(a)
+} else {
+  func(b)
+}
+
+// else ifも検出対象
+if (role === 'admin') {
+  sendNotification('admin', user)
+} else if (role === 'moderator') {
+  sendNotification('moderator', user)
+} else {
+  sendNotification('user', user)
+}
+
+// 引数の数が異なる場合も検出
+if (condition) {
+  func(a, b)
+} else {
+  func(c)
+}
+
+// メソッドチェーン全体が一致する場合
+if (x) {
+  api.post('/endpoint').send(dataA)
+} else {
+  api.post('/endpoint').send(dataB)
+}
+```
+
+### パターン2: early returnパターン
+
+```javascript
+function handler() {
+  if (role === 'admin') {
+    return notify('admin', { priority: 'high' })
+  }
+  return notify('user', { priority: 'normal' })
+}
+```
+
+### パターン3: 三項演算子
+
+```javascript
+// 基本的な三項演算子
+const result = condition ? func(a) : func(b)
+
+// ネストした三項演算子
+const result = isAdmin ? notify('admin') : isModerator ? notify('moderator') : notify('user')
+```
+
+### パターン4: JSX/TSX（同じコンポーネント、同じ属性、異なる子要素）
+
+```jsx
+// if-else
+function Component() {
+  if (isAdmin) {
+    return <Hoge name="Admin"><Fuga>{children}</Fuga></Hoge>
+  } else {
+    return <Hoge name="Admin"><Piyo>{children}</Piyo></Hoge>
+  }
+}
+
+// 三項演算子
+const element = isAdmin
+  ? <Container size="large"><AdminPanel /></Container>
+  : <Container size="large"><UserPanel /></Container>
+```
+
+## ✅ Valid
+
+### 関数が異なる場合
+
+```javascript
+if (condition) {
+  func(a)
+} else {
+  otherFunc(b)
+}
+```
+
+### 分岐が1つのみの場合
+
+```javascript
+if (condition) {
+  func(a)
+}
+```
+
+### ブロック内に複数のステートメントがある場合
+
+```javascript
+if (condition) {
+  doSomething()
+  func(a)
+} else {
+  func(b)
+}
+```
+
+### JSX: 属性が異なる場合
+
+```jsx
+// UserCardコンポーネントの属性が異なるため、許容される
+if (isAdmin) {
+  return <UserCard name="Admin" role="admin" />
+} else {
+  return <UserCard name="User" role="user" />
+}
+```
+
+### JSX: コンポーネントが異なる場合
+
+```jsx
+if (condition) {
+  return <ComponentA>{children}</ComponentA>
+} else {
+  return <ComponentB>{children}</ComponentB>
+}
+```
+
+## 修正方法
+
+このルールは様々なパターンがあるため、自動修正は提供していません。以下の方法を検討してください。
+
+### 方法1: 引数を条件分岐にする
+
+```javascript
+// Before
+if (condition) {
+  func(a)
+} else {
+  func(b)
+}
+
+// After
+func(condition ? a : b)
+```
+
+### 方法2: オブジェクトを使う
+
+```javascript
+// Before
+if (role === 'admin') {
+  sendNotification('admin', user)
+} else if (role === 'moderator') {
+  sendNotification('moderator', user)
+} else {
+  sendNotification('user', user)
+}
+
+// After
+const roleMap = {
+  admin: 'admin',
+  moderator: 'moderator',
+  user: 'user',
+}
+sendNotification(roleMap[role] || 'user', user)
+```
+
+### 方法3: JSXの子要素を条件分岐にする
+
+```jsx
+// Before
+if (isAdmin) {
+  return <Hoge name="Admin"><Fuga>{children}</Fuga></Hoge>
+} else {
+  return <Hoge name="Admin"><Piyo>{children}</Piyo></Hoge>
+}
+
+// After
+return (
+  <Hoge name="Admin">
+    {isAdmin ? <Fuga>{children}</Fuga> : <Piyo>{children}</Piyo>}
+  </Hoge>
+)
+```
+
+## 注意点
+
+- メソッドチェーンは完全一致で検出します。例えば、`api.post('/endpoint1').send(dataA)` と `api.post('/endpoint2').send(dataB)` は検出されません（エンドポイントが異なるため）。
+- JSXの場合、コンポーネント名と属性（値を含む）が完全に一致する場合のみ検出します。子要素の違いは検出対象です。

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation/index.js
@@ -1,0 +1,280 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'すべての分岐で同じ関数を呼び出している場合、引数のみを条件分岐にすることを推奨します',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    messages: {
+      consolidateFunctionCall:
+        'すべての分岐で同じ関数 "{{functionName}}" を呼び出しています。引数のみを条件分岐にすることを検討してください。\n - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation',
+      consolidateJSXElement:
+        'すべての分岐で同じコンポーネント <{{componentName}}> を使用しています。子要素のみを条件分岐にすることを検討してください。\n - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const sourceCode = context.getSourceCode()
+
+    /**
+     * CallExpressionから関数名を取得
+     */
+    function getFunctionName(node) {
+      if (node.type !== 'CallExpression') return null
+
+      const { callee } = node
+      if (callee.type === 'Identifier') {
+        return callee.name
+      }
+      if (callee.type === 'MemberExpression') {
+        // メソッドチェーン全体のテキストを返す
+        return sourceCode.getText(callee)
+      }
+      return null
+    }
+
+    /**
+     * JSXElementからコンポーネント名を取得
+     */
+    function getJSXElementName(node) {
+      if (node.type !== 'JSXElement') return null
+      const openingElement = node.openingElement
+      if (openingElement.name.type === 'JSXIdentifier') {
+        return openingElement.name.name
+      }
+      if (openingElement.name.type === 'JSXMemberExpression') {
+        return sourceCode.getText(openingElement.name)
+      }
+      return null
+    }
+
+    /**
+     * JSXElementから属性を抽出（スプレッド以外）
+     */
+    function extractJSXAttributes(node) {
+      const attrs = node.openingElement.attributes
+        .filter((attr) => attr.type === 'JSXAttribute')
+        .map((attr) => ({
+          name: attr.name.name,
+          value: sourceCode.getText(attr.value || attr), // valueがない場合はattr全体
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+      return attrs
+    }
+
+    /**
+     * 2つの属性配列が等しいか比較
+     */
+    function areAttributesEqual(attrs1, attrs2) {
+      if (attrs1.length !== attrs2.length) return false
+      for (let i = 0; i < attrs1.length; i++) {
+        if (attrs1[i].name !== attrs2[i].name || attrs1[i].value !== attrs2[i].value) {
+          return false
+        }
+      }
+      return true
+    }
+
+    /**
+     * ExpressionStatementまたはReturnStatementからCallExpressionを取得
+     */
+    function getCallExpression(statement) {
+      if (!statement) return null
+      if (statement.type === 'ExpressionStatement' && statement.expression.type === 'CallExpression') {
+        return statement.expression
+      }
+      if (statement.type === 'ReturnStatement' && statement.argument?.type === 'CallExpression') {
+        return statement.argument
+      }
+      return null
+    }
+
+    /**
+     * ExpressionStatementまたはReturnStatementからJSXElementを取得
+     */
+    function getJSXElement(statement) {
+      if (!statement) return null
+      if (statement.type === 'ReturnStatement' && statement.argument?.type === 'JSXElement') {
+        return statement.argument
+      }
+      return null
+    }
+
+    /**
+     * BlockStatementから実行される単一のステートメントを取得
+     */
+    function getSingleStatement(block) {
+      if (!block) return null
+      if (block.type === 'BlockStatement') {
+        // ブロック内に1つのステートメントのみ
+        if (block.body.length === 1) {
+          return block.body[0]
+        }
+        return null
+      }
+      // BlockStatementでない場合はそのまま返す
+      return block
+    }
+
+    /**
+     * if-else文を検証（early returnパターンも含む）
+     */
+    function checkIfStatement(node) {
+      const branches = []
+
+      // consequent（if部分）
+      const consequentStmt = getSingleStatement(node.consequent)
+      if (!consequentStmt) return
+
+      // alternateを再帰的に収集
+      let current = node
+      while (current) {
+        const consequent = getSingleStatement(current.consequent)
+        if (!consequent) return
+
+        branches.push(consequent)
+
+        if (current.alternate) {
+          if (current.alternate.type === 'IfStatement') {
+            // else if
+            current = current.alternate
+          } else {
+            // else
+            const alternate = getSingleStatement(current.alternate)
+            if (!alternate) return
+            branches.push(alternate)
+            break
+          }
+        } else {
+          // alternateがない場合、early returnパターンをチェック
+          // if文の次のステートメントがreturnかどうか
+          const parent = current.parent
+          if (parent && parent.type === 'BlockStatement') {
+            const ifIndex = parent.body.indexOf(current)
+            if (ifIndex !== -1 && ifIndex + 1 < parent.body.length) {
+              const nextStmt = parent.body[ifIndex + 1]
+              branches.push(nextStmt)
+            }
+          }
+          break
+        }
+      }
+
+      // 分岐が2つ未満の場合は検証不要
+      if (branches.length < 2) return
+
+      // すべての分岐からCallExpressionを取得
+      const callExpressions = branches.map(getCallExpression).filter(Boolean)
+      if (callExpressions.length === branches.length) {
+        // すべて関数呼び出し
+        const functionNames = callExpressions.map(getFunctionName)
+        const firstFunctionName = functionNames[0]
+        if (firstFunctionName && functionNames.every((name) => name === firstFunctionName)) {
+          context.report({
+            node,
+            messageId: 'consolidateFunctionCall',
+            data: { functionName: firstFunctionName },
+          })
+          return
+        }
+      }
+
+      // すべての分岐からJSXElementを取得
+      const jsxElements = branches.map(getJSXElement).filter(Boolean)
+      if (jsxElements.length === branches.length) {
+        // すべてJSX要素
+        const componentNames = jsxElements.map(getJSXElementName)
+        const firstComponentName = componentNames[0]
+        if (firstComponentName && componentNames.every((name) => name === firstComponentName)) {
+          // コンポーネント名が同じ場合、属性も比較
+          const attributes = jsxElements.map(extractJSXAttributes)
+          const firstAttrs = attributes[0]
+          if (attributes.every((attrs) => areAttributesEqual(attrs, firstAttrs))) {
+            context.report({
+              node,
+              messageId: 'consolidateJSXElement',
+              data: { componentName: firstComponentName },
+            })
+          }
+        }
+      }
+    }
+
+    /**
+     * 三項演算子を検証（ネストも含む）
+     */
+    function checkConditionalExpression(node) {
+      const branches = []
+
+      // consequentとalternateを収集
+      function collectBranches(expr) {
+        if (expr.type === 'ConditionalExpression') {
+          collectBranches(expr.consequent)
+          collectBranches(expr.alternate)
+        } else {
+          branches.push(expr)
+        }
+      }
+
+      collectBranches(node)
+
+      // 分岐が2つ未満の場合は検証不要
+      if (branches.length < 2) return
+
+      // すべての分岐がCallExpressionか確認
+      const callExpressions = branches.filter((b) => b.type === 'CallExpression')
+      if (callExpressions.length === branches.length) {
+        const functionNames = callExpressions.map(getFunctionName)
+        const firstFunctionName = functionNames[0]
+        if (firstFunctionName && functionNames.every((name) => name === firstFunctionName)) {
+          context.report({
+            node,
+            messageId: 'consolidateFunctionCall',
+            data: { functionName: firstFunctionName },
+          })
+          return
+        }
+      }
+
+      // すべての分岐がJSXElementか確認
+      const jsxElements = branches.filter((b) => b.type === 'JSXElement')
+      if (jsxElements.length === branches.length) {
+        const componentNames = jsxElements.map(getJSXElementName)
+        const firstComponentName = componentNames[0]
+        if (firstComponentName && componentNames.every((name) => name === firstComponentName)) {
+          // コンポーネント名が同じ場合、属性も比較
+          const attributes = jsxElements.map(extractJSXAttributes)
+          const firstAttrs = attributes[0]
+          if (attributes.every((attrs) => areAttributesEqual(attrs, firstAttrs))) {
+            context.report({
+              node,
+              messageId: 'consolidateJSXElement',
+              data: { componentName: firstComponentName },
+            })
+          }
+        }
+      }
+    }
+
+    return {
+      IfStatement(node) {
+        // 最上位のif文のみ検証（ネストしたif文は親で処理される）
+        if (node.parent.type !== 'IfStatement' || node.parent.alternate !== node) {
+          checkIfStatement(node)
+        }
+      },
+      ConditionalExpression(node) {
+        // 最上位の三項演算子のみ検証（ネストした三項演算子は親で処理される）
+        if (
+          node.parent.type !== 'ConditionalExpression' ||
+          (node.parent.consequent !== node && node.parent.alternate !== node)
+        ) {
+          checkConditionalExpression(node)
+        }
+      },
+    }
+  },
+}

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation/index.js
@@ -52,17 +52,10 @@ module.exports = {
     }
 
     /**
-     * JSXElementから属性を抽出（スプレッド以外）
+     * JSXElementから属性を抽出（spread含む全属性をテキスト化）
      */
     function extractJSXAttributes(node) {
-      const attrs = node.openingElement.attributes
-        .filter((attr) => attr.type === 'JSXAttribute')
-        .map((attr) => ({
-          name: attr.name.name,
-          value: sourceCode.getText(attr.value || attr), // valueがない場合はattr全体
-        }))
-        .sort((a, b) => a.name.localeCompare(b.name))
-      return attrs
+      return node.openingElement.attributes.map((attr) => sourceCode.getText(attr))
     }
 
     /**
@@ -71,7 +64,7 @@ module.exports = {
     function areAttributesEqual(attrs1, attrs2) {
       if (attrs1.length !== attrs2.length) return false
       for (let i = 0; i < attrs1.length; i++) {
-        if (attrs1[i].name !== attrs2[i].name || attrs1[i].value !== attrs2[i].value) {
+        if (attrs1[i] !== attrs2[i]) {
           return false
         }
       }

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-function-call-consolidation.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-function-call-consolidation.js
@@ -70,6 +70,30 @@ ruleTester.run('best-practice-for-function-call-consolidation', rule, {
         }
       `,
     },
+    // JSX: spread attributesの内容が異なる
+    {
+      code: `
+        function Component() {
+          if (condition) {
+            return <Hoge {...propsA}><Fuga></Fuga></Hoge>
+          } else {
+            return <Hoge {...propsB}><Piyo></Piyo></Hoge>
+          }
+        }
+      `,
+    },
+    // JSX: spreadがある/ない
+    {
+      code: `
+        function Component() {
+          if (condition) {
+            return <Hoge name="test"><Fuga></Fuga></Hoge>
+          } else {
+            return <Hoge {...props}><Piyo></Piyo></Hoge>
+          }
+        }
+      `,
+    },
   ],
   invalid: [
     // ========================================
@@ -235,6 +259,42 @@ ruleTester.run('best-practice-for-function-call-consolidation', rule, {
         {
           messageId: 'consolidateJSXElement',
           data: { componentName: 'Container', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // JSX: spread attributesが同じ
+    {
+      code: `
+        function Component() {
+          if (condition) {
+            return <Hoge {...props}><Fuga></Fuga></Hoge>
+          } else {
+            return <Hoge {...props}><Piyo></Piyo></Hoge>
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateJSXElement',
+          data: { componentName: 'Hoge', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // JSX: spread + 通常の属性が同じ
+    {
+      code: `
+        function Component() {
+          if (condition) {
+            return <Hoge {...props} name="test"><Fuga></Fuga></Hoge>
+          } else {
+            return <Hoge {...props} name="test"><Piyo></Piyo></Hoge>
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateJSXElement',
+          data: { componentName: 'Hoge', detailLink: DETAIL_LINK },
         },
       ],
     },

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-function-call-consolidation.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-function-call-consolidation.js
@@ -1,0 +1,242 @@
+const rule = require('../rules/best-practice-for-function-call-consolidation')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+const DETAIL_LINK = `\n - 詳細: https://github.com/kufu/tamatebako/tree/master/packages/eslint-plugin-smarthr/rules/best-practice-for-function-call-consolidation`
+
+ruleTester.run('best-practice-for-function-call-consolidation', rule, {
+  valid: [
+    // 関数が異なる
+    {
+      code: `
+        if (condition) {
+          func(a)
+        } else {
+          otherFunc(b)
+        }
+      `,
+    },
+    // 分岐が1つのみ
+    {
+      code: `
+        if (condition) {
+          func(a)
+        }
+      `,
+    },
+    // ブロック内に複数のステートメント
+    {
+      code: `
+        if (condition) {
+          doSomething()
+          func(a)
+        } else {
+          func(b)
+        }
+      `,
+    },
+    // JSX: 属性が異なる
+    {
+      code: `
+        function Component() {
+          if (isAdmin) {
+            return <UserCard name="Admin" role="admin" />
+          } else {
+            return <UserCard name="User" role="user" />
+          }
+        }
+      `,
+    },
+    // JSX: コンポーネントが異なる
+    {
+      code: `
+        function Component() {
+          if (condition) {
+            return <ComponentA>{children}</ComponentA>
+          } else {
+            return <ComponentB>{children}</ComponentB>
+          }
+        }
+      `,
+    },
+  ],
+  invalid: [
+    // ========================================
+    // if-else文
+    // ========================================
+    // 基本的なif-else
+    {
+      code: `
+        if (condition) {
+          func(a)
+        } else {
+          func(b)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateFunctionCall',
+          data: { functionName: 'func', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // else if
+    {
+      code: `
+        if (role === 'admin') {
+          sendNotification('admin', user)
+        } else if (role === 'moderator') {
+          sendNotification('moderator', user)
+        } else {
+          sendNotification('user', user)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateFunctionCall',
+          data: { functionName: 'sendNotification', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // 引数の数が異なる
+    {
+      code: `
+        if (condition) {
+          func(a, b)
+        } else {
+          func(c)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateFunctionCall',
+          data: { functionName: 'func', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // メソッドチェーン（全体が一致）
+    {
+      code: `
+        if (x) {
+          api.post('/endpoint').send(dataA)
+        } else {
+          api.post('/endpoint').send(dataB)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateFunctionCall',
+          data: { functionName: 'api.post(\'/endpoint\').send', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // early returnパターン
+    {
+      code: `
+        function handler() {
+          if (role === 'admin') {
+            return notify('admin', { priority: 'high' })
+          }
+          return notify('user', { priority: 'normal' })
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateFunctionCall',
+          data: { functionName: 'notify', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+
+    // ========================================
+    // 三項演算子
+    // ========================================
+    // 基本的な三項演算子
+    {
+      code: `
+        const result = condition ? func(a) : func(b)
+      `,
+      errors: [
+        {
+          messageId: 'consolidateFunctionCall',
+          data: { functionName: 'func', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // ネストした三項演算子
+    {
+      code: `
+        const result = isAdmin ? notify('admin') : isModerator ? notify('moderator') : notify('user')
+      `,
+      errors: [
+        {
+          messageId: 'consolidateFunctionCall',
+          data: { functionName: 'notify', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+
+    // ========================================
+    // JSX
+    // ========================================
+    // 基本的なJSX（同じコンポーネント、同じ属性、異なる子要素）
+    {
+      code: `
+        function Component() {
+          if (isAdmin) {
+            return <Hoge name="Admin"><Fuga>{children}</Fuga></Hoge>
+          } else {
+            return <Hoge name="Admin"><Piyo>{children}</Piyo></Hoge>
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateJSXElement',
+          data: { componentName: 'Hoge', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // JSX: 属性なし
+    {
+      code: `
+        function Component() {
+          if (condition) {
+            return <Wrapper><ChildA /></Wrapper>
+          } else {
+            return <Wrapper><ChildB /></Wrapper>
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateJSXElement',
+          data: { componentName: 'Wrapper', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // JSX: 三項演算子
+    {
+      code: `
+        const element = isAdmin ? <Container size="large"><AdminPanel /></Container> : <Container size="large"><UserPanel /></Container>
+      `,
+      errors: [
+        {
+          messageId: 'consolidateJSXElement',
+          data: { componentName: 'Container', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
## Summary

すべての分岐で同じ関数を呼び出している場合に検出し、引数のみを条件分岐にすることを推奨するルールを追加。

### 検出パターン

- **if-else文** - else if含む、すべての分岐で同じ関数を呼び出す
- **early returnパターン** - if文の後のreturn文も検出
- **三項演算子** - ネストした三項演算子も対応
- **JSX/TSX** - 同じコンポーネント、同じ属性（spread attributes含む）、異なる子要素

### 特徴

- 検出のみで自動修正は提供しない（修正方法は状況により異なるため）
- メソッドチェーンは完全一致で比較（`api.post('/endpoint1')` と `api.post('/endpoint2')` は別物）
- JSXのspread attributes（`{...props}`）も含めて全属性を比較
- 引数の数が異なる場合も検出

### テスト

- 19件のテストケース（valid: 9件、invalid: 10件）
- spread attributesの動作も含めて検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)