### PR TITLE
feat: eslint-plugin-smarthrをv6.22.0に更新してbest-practice-for-reduce-redundant-callsを導入

### DIFF
--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -67,6 +67,7 @@ export default [
       'smarthr/best-practice-for-unstable-dependencies': 'warn', // TODO: 2026/06に導入。導入したプロダクトの数に応じてerror化を検討予定
       'smarthr/best-practice-for-optional-chaining': 'error',
       'smarthr/best-practice-for-prohibit-import-smarthr-ui-local': 'error',
+      'smarthr/best-practice-for-reduce-redundant-calls': 'warn', // TODO: 2026/07に導入。問題なければerror化を検討予定
       'smarthr/best-practice-for-remote-trigger-dialog': 'error',
       'smarthr/best-practice-for-rest-parameters': 'off', // TODO: 2025/12に導入。導入したプロダクトの数に応じてerror化を検討予定
       'smarthr/best-practice-for-spread-syntax': [ 'error', { fix: true } ],

--- a/packages/eslint-config-smarthr/package.json
+++ b/packages/eslint-config-smarthr/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-smarthr": "6.21.2",
+    "eslint-plugin-smarthr": "6.22.0",
     "globals": "^17.6.0",
     "typescript-eslint": "^8.56.1"
   }

--- a/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
@@ -3075,6 +3075,9 @@ exports[`should match ESLint Configuration snapshot 1`] = `
     "smarthr/best-practice-for-prohibit-import-smarthr-ui-local": [
       2,
     ],
+    "smarthr/best-practice-for-reduce-redundant-calls": [
+      1,
+    ],
     "smarthr/best-practice-for-remote-trigger-dialog": [
       2,
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-smarthr:
-        specifier: 6.21.2
-        version: 6.21.2(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.22.0
+        version: 6.22.0(eslint@9.39.4(jiti@2.4.2))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -3853,6 +3853,11 @@ packages:
 
   eslint-plugin-smarthr@6.21.2:
     resolution: {integrity: sha512-M0s/aNBx/ozaq0RyIACKdwx+gMFoW7Ivu61o7N+u/J9n0RZGCkxKQiKhDiO9DVKIkmCPWzBjLl0wUMYvaAih5A==}
+    peerDependencies:
+      eslint: ^9
+
+  eslint-plugin-smarthr@6.22.0:
+    resolution: {integrity: sha512-P+4K8vXJAhHBoPQ3NdDXVJJklHRxvFxa/3yS7GWlal3F/aA37GaKERhxbei2OOpe6ErK3dO7TLLFXdb0V2xRAA==}
     peerDependencies:
       eslint: ^9
 
@@ -10502,6 +10507,11 @@ snapshots:
       json5: 2.2.3
 
   eslint-plugin-smarthr@6.21.2(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.4.2)
+      json5: 2.2.3
+
+  eslint-plugin-smarthr@6.22.0(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## Summary

eslint-config-smarthrでeslint-plugin-smarthrをv6.22.0に更新し、新規ルールbest-practice-for-reduce-redundant-callsを導入しました。

### 変更内容

**eslint-plugin-smarthrの更新:**
- 6.21.2 → 6.22.0

**新規ルール導入:**
- `smarthr/best-practice-for-reduce-redundant-calls`: warn
- TODO: 2026/07に導入。問題なければerror化を検討予定

### ルールの概要

if-else分岐やswitch文で同じ関数を重複して呼び出している場合に警告を出すルールです。

```typescript
// ❌ Bad
if (condition) {
  return f()
} else {
  return f()
}

// ✅ Good
return f()
```

### テスト

- スナップショットテスト: ✅ 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)