### PR TITLE
fix: best-practice-for-reduce-redundant-callsでJSX属性の差分数に基づいて検出するように改善

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/README.md
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/README.md
@@ -106,22 +106,40 @@ const result = isAdmin ? notify('admin') : isModerator ? notify('moderator') : n
 ### パターン4: JSX/TSX
 
 **子要素なし（セルフクロージングタグ）の場合:**
-同じコンポーネント名なら、属性が異なっても検出されます。
+同じコンポーネント名で、属性の差分が**1つだけ**の場合に検出されます。
 
 ```jsx
-// 子要素なし、属性が異なる（検出される）
+// 属性の差分が1つ（role のみ異なる）→ 検出される
 function Component() {
-  if (isAdmin) {
-    return <UserCard name="Admin" role="admin" />
+  if (isModerator) {
+    return <UserCard role="moderator" />
   } else {
-    return <UserCard name="User" role="user" />
+    return <UserCard role="user" />
+  }
+}
+
+// 属性の差分が1つ（role のみ異なる、他は同じ）→ 検出される
+function Component({ data }) {
+  if (isModerator) {
+    return <UserCard role="moderator" hoge={data} />
+  } else {
+    return <UserCard role="user" hoge={data} />
+  }
+}
+
+// boolean属性の差分が1つ → 検出される
+function Component() {
+  if (condition) {
+    return <Component hoge={true} fuga={false} />
+  } else {
+    return <Component hoge={true} fuga={false} piyo />
   }
 }
 
 // 三項演算子
-const element = isAdmin
-  ? <UserCard name="Admin" role="admin" />
-  : <UserCard name="User" role="user" />
+const element = isModerator
+  ? <UserCard role="moderator" hoge={data} />
+  : <UserCard role="user" hoge={data} />
 ```
 
 **子要素あり の場合:**
@@ -251,6 +269,28 @@ if (condition) {
   func(a)
 } else {
   func(b)
+}
+```
+
+### JSX: 子要素なし、属性の差分が2つ以上の場合
+
+```jsx
+// 属性の差分が2つ以上（name と role が異なる）→ 意図的に分けていると判断
+function Component() {
+  if (isAdmin) {
+    return <UserCard name="Admin" role="admin" />
+  } else {
+    return <UserCard name="User" role="user" />
+  }
+}
+
+// FormattedMessage（id と defaultMessage が異なる = 差分2つ）
+function Component({ searchKeyword }) {
+  return searchKeyword === '' ? (
+    <FormattedMessage id="userRoles/addDialog/noUser" defaultMessage="追加できるアカウントがありません" />
+  ) : (
+    <FormattedMessage id="userRoles/addDialog/noResult" defaultMessage="該当するアカウントがありません" />
+  )
 }
 ```
 
@@ -451,10 +491,10 @@ return (
 
 - メソッドチェーンは完全一致で検出します。例えば、`api.post('/endpoint1').send(dataA)` と `api.post('/endpoint2').send(dataB)` は検出されません（エンドポイントが異なるため）。
 - **JSXの検出条件:**
-  - **子要素なし（self-closing）の場合:** 同じコンポーネント名なら、属性が異なっても検出します。
+  - **子要素なし（self-closing）の場合:** 同じコンポーネント名で、属性の差分が1つだけの場合に検出します。差分が2つ以上の場合は、意図的に分けていると判断して検出しません。
   - **子要素ありの場合:** 同じコンポーネント名、同じ属性（値を含む）で、子要素が異なる場合に検出します。
   - **React.FragmentとFragmentは除外されます。** これらは単なるグループ化のためのものなので、検出対象外です。
-- JSXのspread attributes（`{...props}`）も含めて全属性を比較します。spreadの変数名が異なる場合（`{...propsA}` vs `{...propsB}`）は検出されません。
+- JSXのspread attributes（`{...props}`）がある場合は、完全一致のみ検出します。spreadの変数名が異なる場合（`{...propsA}` vs `{...propsB}`）や、片方だけspreadがある場合は検出されません。
 - **if文/switch文のearly returnパターン:** すべてのブランチが`return`で終わっている場合のみ、次のステートメントも検出対象に含まれます。`break`を使う場合は含まれません。
 - **switch文のfall-through:** 空のcaseは次のcaseにfall-throughし、最初に見つかった処理を実行するものとして扱います。
 - **switch文のdefaultケース:** defaultケースは最後のcaseなので、breakがなくても許容されます。

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/index.js
@@ -67,7 +67,7 @@ module.exports = {
       }
 
       const firstSelfClosing = jsxElements[0].openingElement.selfClosing
-      let firstOpeningTag = undefined
+      const firstOpeningTag = sourceCode.getText(jsxElements[0].openingElement)
 
       // 1つのループで全チェック（早期終了可能）
       for (let i = 1; i < jsxElements.length; i++) {
@@ -79,15 +79,10 @@ module.exports = {
           return
         }
 
-        // selfClosingでない場合は開始タグ全体を比較（属性含む）
-        if (!firstSelfClosing) {
-          if (firstOpeningTag === undefined) {
-            firstOpeningTag = sourceCode.getText(jsxElements[0].openingElement)
-          }
-
-          if (sourceCode.getText(jsxElements[i].openingElement) !== firstOpeningTag) {
-            return
-          }
+        // 開始タグ全体を比較（属性含む）
+        // 属性が異なる場合は意図的に分けている可能性が高いため検出しない
+        if (sourceCode.getText(jsxElements[i].openingElement) !== firstOpeningTag) {
+          return
         }
       }
 

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/index.js
@@ -67,11 +67,52 @@ module.exports = {
       }
 
       const firstSelfClosing = jsxElements[0].openingElement.selfClosing
-      const firstOpeningTag = sourceCode.getText(jsxElements[0].openingElement)
+      const firstAttrs = jsxElements[0].openingElement.attributes
 
-      // 1つのループで全チェック（早期終了可能）
+      // Spread attributesがある場合は厳密比較のみ
+      const hasSpread = firstAttrs.some((a) => a.type === 'JSXSpreadAttribute')
+      if (hasSpread) {
+        const firstOpeningTag = sourceCode.getText(jsxElements[0].openingElement)
+
+        for (let i = 1; i < jsxElements.length; i++) {
+          if (
+            jsxElements[i].openingElement.selfClosing !== firstSelfClosing ||
+            getJSXElementName(jsxElements[i]) !== firstComponentName
+          ) {
+            return
+          }
+
+          // Spreadがある場合は完全一致のみ許可
+          if (jsxElements[i].openingElement.attributes.some((a) => a.type === 'JSXSpreadAttribute')) {
+            if (sourceCode.getText(jsxElements[i].openingElement) !== firstOpeningTag) {
+              return
+            }
+          } else {
+            // 片方だけSpreadがある場合は差分2以上として除外
+            return
+          }
+        }
+
+        context.report({
+          node,
+          messageId: 'consolidateJSXElement',
+          data: { componentName: firstComponentName },
+        })
+        return
+      }
+
+      // 最初の要素の属性Mapを作成（1回のみ）
+      const firstAttrMap = new Map()
+      for (const attr of firstAttrs) {
+        if (attr.type === 'JSXAttribute') {
+          const name = attr.name.name
+          const value = attr.value ? sourceCode.getText(attr.value) : 'true'
+          firstAttrMap.set(name, value)
+        }
+      }
+
+      // 各要素と比較
       for (let i = 1; i < jsxElements.length; i++) {
-        // selfClosingとコンポーネント名をチェック
         if (
           jsxElements[i].openingElement.selfClosing !== firstSelfClosing ||
           getJSXElementName(jsxElements[i]) !== firstComponentName
@@ -79,10 +120,41 @@ module.exports = {
           return
         }
 
-        // 開始タグ全体を比較（属性含む）
-        // 属性が異なる場合は意図的に分けている可能性が高いため検出しない
-        if (sourceCode.getText(jsxElements[i].openingElement) !== firstOpeningTag) {
+        const currentAttrs = jsxElements[i].openingElement.attributes
+
+        // Spreadがある場合は除外
+        if (currentAttrs.some((a) => a.type === 'JSXSpreadAttribute')) {
           return
+        }
+
+        // 差分カウント（2以上で早期リターン）
+        let diffCount = 0
+        const checkedKeys = new Set()
+
+        // 現在の要素の属性を走査
+        for (const attr of currentAttrs) {
+          if (attr.type === 'JSXAttribute') {
+            const name = attr.name.name
+            const value = attr.value ? sourceCode.getText(attr.value) : 'true'
+            checkedKeys.add(name)
+
+            if (!firstAttrMap.has(name) || firstAttrMap.get(name) !== value) {
+              diffCount++
+              if (diffCount >= 2) {
+                return // 差分2以上 → 意図的に分けている
+              }
+            }
+          }
+        }
+
+        // 最初の要素にしかない属性もカウント
+        for (const key of firstAttrMap.keys()) {
+          if (!checkedKeys.has(key)) {
+            diffCount++
+            if (diffCount >= 2) {
+              return
+            }
+          }
         }
       }
 

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/index.js
@@ -75,20 +75,13 @@ module.exports = {
         const firstOpeningTag = sourceCode.getText(jsxElements[0].openingElement)
 
         for (let i = 1; i < jsxElements.length; i++) {
+          // Spreadがある場合は完全一致のみ許可、片方だけSpreadがある場合は除外
           if (
             jsxElements[i].openingElement.selfClosing !== firstSelfClosing ||
-            getJSXElementName(jsxElements[i]) !== firstComponentName
+            getJSXElementName(jsxElements[i]) !== firstComponentName ||
+            !jsxElements[i].openingElement.attributes.some((a) => a.type === 'JSXSpreadAttribute') ||
+            sourceCode.getText(jsxElements[i].openingElement) !== firstOpeningTag
           ) {
-            return
-          }
-
-          // Spreadがある場合は完全一致のみ許可
-          if (jsxElements[i].openingElement.attributes.some((a) => a.type === 'JSXSpreadAttribute')) {
-            if (sourceCode.getText(jsxElements[i].openingElement) !== firstOpeningTag) {
-              return
-            }
-          } else {
-            // 片方だけSpreadがある場合は差分2以上として除外
             return
           }
         }

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
@@ -423,12 +423,6 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         }
       `,
     },
-    // JSX: ネストした三項演算子、selfClosing、属性が異なる
-    {
-      code: `
-        const element = isAdmin ? <UserCard role="admin" /> : isModerator ? <UserCard role="moderator" /> : <UserCard role="user" />
-      `,
-    },
   ],
   invalid: [
     // ========================================
@@ -1096,6 +1090,66 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         {
           messageId: 'consolidateJSXElement',
           data: { componentName: 'Layout', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // JSX: ネストした三項演算子、selfClosing、属性の差分が1つ
+    {
+      code: `
+        const element = isAdmin ? <UserCard role="admin" /> : isModerator ? <UserCard role="moderator" /> : <UserCard role="user" />
+      `,
+      errors: [
+        {
+          messageId: 'consolidateJSXElement',
+          data: { componentName: 'UserCard', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // JSX: selfClosing、属性の差分が1つ、他の属性は同じ
+    {
+      code: `
+        function Component({ data }) {
+          if (isModerator) {
+            return <UserCard role="moderator" hoge={data} />
+          } else {
+            return <UserCard role="user" hoge={data} />
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateJSXElement',
+          data: { componentName: 'UserCard', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // JSX: selfClosing、boolean属性の差分が1つ
+    {
+      code: `
+        function Component() {
+          if (condition) {
+            return <Component hoge={true} fuga={false} />
+          } else {
+            return <Component hoge={true} fuga={false} piyo />
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateJSXElement',
+          data: { componentName: 'Component', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // JSX: 三項演算子、属性の差分が1つ
+    {
+      code: `
+        const element = isModerator ? <UserCard role="moderator" hoge={data} /> : <UserCard role="user" hoge={data} />
+      `,
+      errors: [
+        {
+          messageId: 'consolidateJSXElement',
+          data: { componentName: 'UserCard', detailLink: DETAIL_LINK },
         },
       ],
     },

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
@@ -367,6 +367,68 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         const element = condition ? <ComponentA>{child}</ComponentA> : <ComponentB>{child}</ComponentB>
       `,
     },
+    // JSX: selfClosing、属性が異なる（意図的に分けている）
+    {
+      code: `
+        function Component() {
+          if (isAdmin) {
+            return <UserCard name="Admin" role="admin" />
+          } else {
+            return <UserCard name="User" role="user" />
+          }
+        }
+      `,
+    },
+    // JSX: 三項演算子、selfClosing、属性が異なる
+    {
+      code: `
+        const element = isAdmin ? <UserCard name="Admin" role="admin" /> : <UserCard name="User" role="user" />
+      `,
+    },
+    // JSX: switch、selfClosing、属性が異なる
+    {
+      code: `
+        function Component() {
+          switch (type) {
+            case 'admin':
+              return <UserCard name="Admin" role="admin" />
+            case 'user':
+              return <UserCard name="User" role="user" />
+            default:
+              return <UserCard name="Guest" role="guest" />
+          }
+        }
+      `,
+    },
+    // JSX: selfClosing、FormattedMessage（属性が異なる）
+    {
+      code: `
+        function Component({ searchKeyword }) {
+          return searchKeyword === '' ? (
+            <FormattedMessage id="userRoles/addDialog/noUser" defaultMessage="追加できるアカウントがありません" />
+          ) : (
+            <FormattedMessage id="userRoles/addDialog/noResult" defaultMessage="該当するアカウントがありません" />
+          )
+        }
+      `,
+    },
+    // JSX: early return、selfClosing、属性が異なる
+    {
+      code: `
+        function Component() {
+          if (isAdmin) {
+            return <UserCard name="Admin" role="admin" />
+          }
+          return <UserCard name="User" role="user" />
+        }
+      `,
+    },
+    // JSX: ネストした三項演算子、selfClosing、属性が異なる
+    {
+      code: `
+        const element = isAdmin ? <UserCard role="admin" /> : isModerator ? <UserCard role="moderator" /> : <UserCard role="user" />
+      `,
+    },
   ],
   invalid: [
     // ========================================
@@ -474,23 +536,6 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         },
       ],
     },
-    // early return: JSX
-    {
-      code: `
-        function Component() {
-          if (isAdmin) {
-            return <UserCard name="Admin" role="admin" />
-          }
-          return <UserCard name="User" role="user" />
-        }
-      `,
-      errors: [
-        {
-          messageId: 'consolidateJSXElement',
-          data: { componentName: 'UserCard', detailLink: DETAIL_LINK },
-        },
-      ],
-    },
     // early return: メソッドチェーン
     {
       code: `
@@ -589,18 +634,6 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         {
           messageId: 'consolidateJSXElement',
           data: { componentName: 'Layout', detailLink: DETAIL_LINK },
-        },
-      ],
-    },
-    // ネストした三項演算子でJSX（子要素なし）
-    {
-      code: `
-        const element = isAdmin ? <UserCard role="admin" /> : isModerator ? <UserCard role="moderator" /> : <UserCard role="user" />
-      `,
-      errors: [
-        {
-          messageId: 'consolidateJSXElement',
-          data: { componentName: 'UserCard', detailLink: DETAIL_LINK },
         },
       ],
     },
@@ -941,24 +974,6 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
     // ========================================
     // JSX
     // ========================================
-    // JSX: 子要素なし、属性が異なる
-    {
-      code: `
-        function Component() {
-          if (isAdmin) {
-            return <UserCard name="Admin" role="admin" />
-          } else {
-            return <UserCard name="User" role="user" />
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: 'consolidateJSXElement',
-          data: { componentName: 'UserCard', detailLink: DETAIL_LINK },
-        },
-      ],
-    },
     // 基本的なJSX（同じコンポーネント、同じ属性、異なる子要素）
     {
       code: `
@@ -1004,18 +1019,6 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         {
           messageId: 'consolidateJSXElement',
           data: { componentName: 'Container', detailLink: DETAIL_LINK },
-        },
-      ],
-    },
-    // JSX: 三項演算子、子要素なし、属性が異なる
-    {
-      code: `
-        const element = isAdmin ? <UserCard name="Admin" role="admin" /> : <UserCard name="User" role="user" />
-      `,
-      errors: [
-        {
-          messageId: 'consolidateJSXElement',
-          data: { componentName: 'UserCard', detailLink: DETAIL_LINK },
         },
       ],
     },
@@ -1093,27 +1096,6 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         {
           messageId: 'consolidateJSXElement',
           data: { componentName: 'Layout', detailLink: DETAIL_LINK },
-        },
-      ],
-    },
-    // JSX: switch、子要素なし、属性が異なる
-    {
-      code: `
-        function Component() {
-          switch (type) {
-            case 'admin':
-              return <UserCard name="Admin" role="admin" />
-            case 'user':
-              return <UserCard name="User" role="user" />
-            default:
-              return <UserCard name="Guest" role="guest" />
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: 'consolidateJSXElement',
-          data: { componentName: 'UserCard', detailLink: DETAIL_LINK },
         },
       ],
     },

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
@@ -94,6 +94,42 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         }
       `,
     },
+    // JSX: selfClosing、spread attributesの内容が異なる
+    {
+      code: `
+        function Component() {
+          if (condition) {
+            return <Component {...propsA} />
+          } else {
+            return <Component {...propsB} />
+          }
+        }
+      `,
+    },
+    // JSX: selfClosing、spreadがある/ない
+    {
+      code: `
+        function Component() {
+          if (condition) {
+            return <Component name="test" />
+          } else {
+            return <Component {...props} />
+          }
+        }
+      `,
+    },
+    // JSX: selfClosing、spread + 通常属性でspreadが異なる
+    {
+      code: `
+        function Component() {
+          if (condition) {
+            return <Component {...propsA} name="test" />
+          } else {
+            return <Component {...propsB} name="test" />
+          }
+        }
+      `,
+    },
     // JSX: React.Fragment（同じ属性、異なる子要素）
     {
       code: `


### PR DESCRIPTION
## Summary

best-practice-for-reduce-redundant-callsルールで、JSX要素（selfClosing）の属性差分数に基づいて検出するように改善しました。

## 変更内容

### 属性の差分カウントロジック

**検出する（差分が1つだけ）:**
```tsx
// roleだけが異なる
<UserCard role="moderator" /> vs <UserCard role="user" />

// roleだけが異なる、他の属性は同じ
<UserCard role="moderator" hoge={data} /> vs <UserCard role="user" hoge={data} />

// boolean属性が1つ追加
<Component hoge fuga /> vs <Component hoge fuga piyo />
```

**検出しない（差分が2つ以上）:**
```tsx
// name と role が異なる（差分2つ）
<UserCard name="Admin" role="admin" /> vs <UserCard name="User" role="user" />

// id と defaultMessage が異なる（差分2つ）
<FormattedMessage id="userRoles/addDialog/noUser" defaultMessage="..." /> vs
<FormattedMessage id="userRoles/addDialog/noResult" defaultMessage="..." />
```

### 実装の工夫

1. **ループ最適化**
   - 最初の要素の属性Mapを1回だけ作成して再利用
   - 各比較で都度Mapを作らない → O(M + K*M) の計算量

2. **早期リターン**
   - 差分が2以上になった時点で即座にリターン
   - 残りの属性を見ない

3. **Spread attributesの扱い**
   - spreadがある場合は完全一致のみ許可
   - 片方だけspreadがある場合は差分2以上として扱う

## 利用者への影響

FormattedMessageのように、複数の属性が異なるケースで不要な警告が出なくなります。

**Before（修正前）:**
- selfClosingの場合、コンポーネント名だけをチェック
- 属性が異なっていても検出 → 誤検出が多い

**After（修正後）:**
- selfClosingの場合も属性の差分をカウント
- 差分が1つのみ → 検出（まとめられる可能性が高い）
- 差分が2つ以上 → 検出しない（意図的に分けている）

## テスト

- 82件すべて通過
- 新規テストケース追加:
  - 属性の差分が1つ（role のみ異なる）
  - 属性の差分が1つ、他は同じ（role + hoge）
  - boolean属性の差分が1つ
  - 三項演算子で属性の差分が1つ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
