### PR TITLE
fix: else句/default句がない場合は検出対象外にする

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/index.js
@@ -306,6 +306,7 @@ module.exports = {
 
       // alternateを再帰的に収集
       let allCasesReturn = true
+      let hasElse = false
       let current = node
       while (current) {
         const consequent = getSingleStatement(current.consequent)
@@ -322,6 +323,7 @@ module.exports = {
             current = current.alternate
           } else {
             // else
+            hasElse = true
             const alternate = getSingleStatement(current.alternate)
             if (!alternate) return
             branches.push(alternate)
@@ -347,15 +349,20 @@ module.exports = {
             }
 
             const nextStmt = parent.body[ifIndex + 1]
-            // 次のreturn文がない場合は検証対象外
-            if (nextStmt.type !== 'ReturnStatement') {
-              return
+            // 次のreturn文がある場合のみ、early returnパターンとして扱う
+            if (nextStmt.type === 'ReturnStatement') {
+              branches.push(nextStmt)
+              hasElse = true // early returnパターンはelse句と同等に扱う
             }
-
-            branches.push(nextStmt)
           }
           break
         }
+      }
+
+      // else句がない（かつearly returnパターンでもない）場合は検証対象外
+      // すべてのケースをカバーしていないため
+      if (!hasElse) {
+        return
       }
 
       // 分岐が2つ未満の場合は検証不要

--- a/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/index.js
+++ b/packages/eslint-plugin-smarthr/rules/best-practice-for-reduce-redundant-calls/index.js
@@ -446,6 +446,7 @@ module.exports = {
       // defaultがない場合、early returnパターンをチェック
       // すべてのcaseがreturnで終わっている場合のみ、次のreturn文を追加
       if (!hasDefault) {
+        let hasEarlyReturn = false
 
         if (allCasesReturn) {
           const parent = node.parent
@@ -461,12 +462,17 @@ module.exports = {
           }
 
           const nextStmt = parent.body[switchIndex + 1]
-          // 次のreturn文がない場合は検証対象外
-          if (nextStmt.type !== 'ReturnStatement') {
-            return
+          // 次のreturn文がある場合のみ、early returnパターンとして扱う
+          if (nextStmt.type === 'ReturnStatement') {
+            branches.push(nextStmt)
+            hasEarlyReturn = true
           }
+        }
 
-          branches.push(nextStmt)
+        // defaultがない（かつearly returnパターンでもない）場合は検証対象外
+        // すべてのケースをカバーしていないため
+        if (!hasEarlyReturn) {
+          return
         }
       }
 

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
@@ -668,6 +668,25 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         },
       ],
     },
+    // if-else（elseあり、同じ関数）+ 次にreturn（同じ関数だが見られない）
+    {
+      code: `
+        function handler() {
+          if (role === 'admin') {
+            return notify('admin')
+          } else {
+            return notify('moderator')
+          }
+          return notify('user')
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateFunctionCall',
+          data: { functionName: 'notify', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
     // early return: 複数のif（すべてreturn）+ 次にreturn
     {
       code: `
@@ -837,6 +856,26 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         {
           messageId: 'consolidateFunctionCall',
           data: { functionName: 'formatMessage', detailLink: DETAIL_LINK },
+        },
+      ],
+    },
+    // switch（defaultあり、同じ関数）+ 次にreturn（同じ関数だが見られない）
+    {
+      code: `
+        function handler() {
+          switch (role) {
+            case 'admin':
+              return notify('admin')
+            default:
+              return notify('moderator')
+          }
+          return notify('user')
+        }
+      `,
+      errors: [
+        {
+          messageId: 'consolidateFunctionCall',
+          data: { functionName: 'notify', detailLink: DETAIL_LINK },
         },
       ],
     },

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
@@ -35,6 +35,25 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         }
       `,
     },
+    // else句がない（すべてのケースをカバーしていない）
+    {
+      code: `
+        if (mode !== 'search') {
+          setMode('search')
+        } else if (q === '') {
+          setMode('default')
+        }
+      `,
+    },
+    {
+      code: `
+        if (a) {
+          func('a')
+        } else if (b) {
+          func('b')
+        }
+      `,
+    },
     // ブロック内に複数のステートメント
     {
       code: `

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
@@ -381,6 +381,33 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         })()
       `,
     },
+    // early return: if-else（elseあり）+ 次にreturn（次のreturnは見られない）
+    {
+      code: `
+        function handler() {
+          if (role === 'admin') {
+            return notify('admin')
+          } else {
+            return otherNotify('moderator')
+          }
+          return notify('user')
+        }
+      `,
+    },
+    // early return: switch（defaultあり）+ 次にreturn（次のreturnは見られない）
+    {
+      code: `
+        function handler() {
+          switch (role) {
+            case 'admin':
+              return notify('admin')
+            default:
+              return otherNotify('moderator')
+          }
+          return notify('user')
+        }
+      `,
+    },
     // メソッドチェーン: 最初のメソッド名が異なる
     {
       code: `

--- a/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
+++ b/packages/eslint-plugin-smarthr/test/best-practice-for-reduce-redundant-calls.js
@@ -223,6 +223,45 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         }
       `,
     },
+    // switch: defaultなし（すべてのケースをカバーしていない）
+    {
+      code: `
+        switch (role) {
+          case 'admin':
+            sendNotification('admin', user)
+            break
+          case 'user':
+            sendNotification('user', user)
+            break
+        }
+      `,
+    },
+    {
+      code: `
+        switch (type) {
+          case 'A':
+            api.post('/endpoint').send(dataA)
+            break
+          case 'B':
+            api.post('/endpoint').send(dataB)
+            break
+        }
+      `,
+    },
+    {
+      code: `
+        switch (role) {
+          case 'admin': {
+            sendNotification('admin', user)
+            break
+          }
+          case 'user': {
+            sendNotification('user', user)
+            break
+          }
+        }
+      `,
+    },
     // switch: defaultなし + switch後に関数が異なる
     {
       code: `
@@ -722,6 +761,8 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
           case 'user':
             sendNotification('user', user)
             break
+          default:
+            sendNotification('guest', user)
         }
       `,
       errors: [
@@ -772,25 +813,6 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         },
       ],
     },
-    // メソッドチェーン
-    {
-      code: `
-        switch (type) {
-          case 'A':
-            api.post('/endpoint').send(dataA)
-            break
-          case 'B':
-            api.post('/endpoint').send(dataB)
-            break
-        }
-      `,
-      errors: [
-        {
-          messageId: 'consolidateFunctionCall',
-          data: { functionName: 'api.post(\'/endpoint\').send', detailLink: DETAIL_LINK },
-        },
-      ],
-    },
     // メソッドチェーン: 3段階（if-else）
     {
       code: `
@@ -817,6 +839,8 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
           case 'B':
             api.post('/endpoint').retry(3).send(dataB)
             break
+          default:
+            api.post('/endpoint').retry(3).send(dataC)
         }
       `,
       errors: [
@@ -883,6 +907,8 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
           case 'C':
             api.post('/endpoint').send(dataC)
             break
+          default:
+            api.post('/endpoint').send(dataD)
         }
       `,
       errors: [
@@ -956,46 +982,6 @@ ruleTester.run('best-practice-for-reduce-redundant-calls', rule, {
         {
           messageId: 'consolidateFunctionCall',
           data: { functionName: 'func', detailLink: DETAIL_LINK },
-        },
-      ],
-    },
-    // defaultなし + caseが2つ以上（break使用）
-    {
-      code: `
-        switch (role) {
-          case 'admin':
-            sendNotification('admin', user)
-            break
-          case 'user':
-            sendNotification('user', user)
-            break
-        }
-      `,
-      errors: [
-        {
-          messageId: 'consolidateFunctionCall',
-          data: { functionName: 'sendNotification', detailLink: DETAIL_LINK },
-        },
-      ],
-    },
-    // switch: 波括弧あり + break
-    {
-      code: `
-        switch (role) {
-          case 'admin': {
-            sendNotification('admin', user)
-            break
-          }
-          case 'user': {
-            sendNotification('user', user)
-            break
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: 'consolidateFunctionCall',
-          data: { functionName: 'sendNotification', detailLink: DETAIL_LINK },
         },
       ],
     },


### PR DESCRIPTION
## 概要

`best-practice-for-reduce-redundant-calls` ルールで、すべてのケースをカバーしていない条件分岐を検出対象外にする修正

## 問題

以下のようなコードが誤検知されていた：

### if-else if（else句なし）
```javascript
if (mode !== 'search') {
  setMode('search')
} else if (q === '') {
  setMode('default')
}
```

このコードには3つのパターンがある：
1. `mode !== 'search'` → `setMode('search')`
2. `mode === 'search' && q === ''` → `setMode('default')`
3. `mode === 'search' && q !== ''` → **何もしない**

すべてのケースで `setMode` を呼んでいるわけではないため、検出すべきではない。

### switch（default句なし）
```javascript
switch (role) {
  case 'admin':
    sendNotification('admin', user)
    break
  case 'user':
    sendNotification('user', user)
    break
}
```

`role` が `'admin'` や `'user'` 以外の値の場合は何もしないため、すべてのケースをカバーしていない。

## 修正内容

### if-else if文
- `hasElse` フラグで `else` 句の有無を追跡
- `else` 句がない場合は検出対象外
- 早期return（`if` の後に `return` がある）パターンは `else` 句と同等に扱う

### switch文
- `hasDefault` フラグで `default` 句の有無を追跡
- `default` 句がない場合は検出対象外
- 早期return（`switch` の後に `return` がある）パターンは `default` 句と同等に扱う

## テスト追加内容

1. else句/default句がない場合のテスト（valid）
2. 早期returnとelse/defaultが共存する場合のテスト（valid）
3. else/defaultがある場合、次のreturnが無視されることの検証（invalid）

全テスト: 95件 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)