### PR TITLE
feat: eslint-plugin-smarthr 6.23.0への更新（oxlint-config-smarthr）

### DIFF
--- a/packages/oxlint-config-smarthr/package.json
+++ b/packages/oxlint-config-smarthr/package.json
@@ -29,7 +29,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "eslint-plugin-smarthr": "6.22.1"
+    "eslint-plugin-smarthr": "6.23.0"
   },
   "peerDependencies": {
     "oxlint": ">=1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
   packages/oxlint-config-smarthr:
     dependencies:
       eslint-plugin-smarthr:
-        specifier: 6.22.1
-        version: 6.22.1(eslint@9.39.4(jiti@2.4.2))
+        specifier: 6.23.0
+        version: 6.23.0(eslint@9.39.4(jiti@2.4.2))
       oxlint:
         specifier: '>=1.0.0'
         version: 1.59.0
@@ -3848,11 +3848,6 @@ packages:
 
   eslint-plugin-smarthr@6.21.0:
     resolution: {integrity: sha512-Awj4j34hE6xyfLYXRbfUWoKG0xQdzc7UGiPwAg7awa3SHouG1wgU8x2Oc63P9bYTos6X1trKPv5x5TLKXPElyQ==}
-    peerDependencies:
-      eslint: ^9
-
-  eslint-plugin-smarthr@6.22.1:
-    resolution: {integrity: sha512-fegDh4SJ0wpS4Wz2ftHT09yVg6jWkjUWP7xXcD0zLcqkYUjQPI/En32gJFiwWIBzApc2YrzCEN0rHgoaX2nbjg==}
     peerDependencies:
       eslint: ^9
 
@@ -10373,11 +10368,6 @@ snapshots:
       string.prototype.repeat: 1.0.0
 
   eslint-plugin-smarthr@6.21.0(eslint@9.39.4(jiti@2.4.2)):
-    dependencies:
-      eslint: 9.39.4(jiti@2.4.2)
-      json5: 2.2.3
-
-  eslint-plugin-smarthr@6.22.1(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
       json5: 2.2.3


### PR DESCRIPTION
## 概要

oxlint-config-smarthrでeslint-plugin-smarthrを6.23.0に更新しました。

## ベースPR

#1457 (eslint-config-smarthr版) をベースに作成

## 更新内容

eslint-plugin-smarthr 6.23.0の主な変更:
- Groupboxコンポーネントのサポート追加（BaseColumnとの互換性維持）
- best-practice-for-reduce-redundant-callsルールの改善
  - else句/default句がない場合は検出対象外に
  - 早期returnパターンの正しいハンドリング

## lockfile確認

pnpm-lock.yamlの変更を確認：
- eslint-plugin-smarthr: 6.22.1 → 6.23.0への移行が正しく反映
- 不要なパッケージの削除
- 新バージョンの追加

全て正常に更新されています ✅

## テスト

全テスト通過 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)