### PR TITLE
feat: update ESLint rule severities in eslint-config-smarthr

### DIFF
--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -73,7 +73,7 @@ export default [
       'smarthr/best-practice-for-spread-syntax': [ 'error', { fix: true } ],
       'smarthr/best-practice-for-tailwind-prohibit-root-margin': 'off',
       'smarthr/best-practice-for-tailwind-variants': 'off',
-      'smarthr/best-practice-for-text-component': 'warn', // TODO: 2026/04にwarn化。問題なければerrorに変更予定
+      'smarthr/best-practice-for-text-component': 'error',
       'smarthr/best-practice-for-unnesessary-early-return': 'off', // TODO: 2025/12に導入。導入したプロダクトの数に応じてerror化を検討予定
       'smarthr/component-name': 'error',
       'smarthr/design-system-guideline-bulk-action-row-button': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -77,7 +77,7 @@ export default [
       'smarthr/best-practice-for-unnesessary-early-return': 'off', // TODO: 2025/12に導入。導入したプロダクトの数に応じてerror化を検討予定
       'smarthr/component-name': 'error',
       'smarthr/design-system-guideline-bulk-action-row-button': 'error',
-      'smarthr/design-system-guideline-prohibit-dialog-button-icon': 'warn', // TODO: 2026/04にwarn化。問題なければerrorに変更予定
+      'smarthr/design-system-guideline-prohibit-dialog-button-icon': 'error',
       'smarthr/design-system-guideline-prohibit-double-icons': 'off',
       'smarthr/design-system-guideline-prohibit-information-panel-in-white-bg': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
       'smarthr/format-import-path': 'off',

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -60,7 +60,7 @@ export default [
       'smarthr/best-practice-for-data-test-attribute': 'off',
       'smarthr/best-practice-for-default-props': 'error',
       'smarthr/best-practice-for-interactive-element': 'error',
-      'smarthr/best-practice-for-lazy-variable': ['warn', { fix: false }], // TODO: 2026/06にwarn化。問題なければerrorに変更予定。fix: false は問題なければ true にする
+      'smarthr/best-practice-for-lazy-variable': ['error', { fix: false }],
       'smarthr/best-practice-for-layouts': 'error',
       'smarthr/best-practice-for-nested-attributes-array-index': 'error',
       'smarthr/best-practice-for-no-unnecessary-variable': 'off',

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -48,7 +48,7 @@ export default [
       'smarthr/a11y-prohibit-checkbox-or-radio-in-table-cell': 'error',
       'smarthr/a11y-prohibit-input-maxlength-attribute': 'error',
       'smarthr/a11y-prohibit-input-placeholder': 'error',
-      'smarthr/a11y-prohibit-overflow-hidden': 'warn', // TODO: 2026/04にwarn化。問題なければerrorに変更予定
+      'smarthr/a11y-prohibit-overflow-hidden': 'error',
       'smarthr/a11y-prohibit-sectioning-content-in-form': 'error',
       'smarthr/a11y-prohibit-useless-sectioning-fragment': 'error',
       'smarthr/a11y-scroller-has-tabindex': 'warn', // TODO: 2026/04にwarn化。問題なければerrorに変更予定

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -67,7 +67,7 @@ export default [
       'smarthr/best-practice-for-unstable-dependencies': 'error',
       'smarthr/best-practice-for-optional-chaining': 'error',
       'smarthr/best-practice-for-prohibit-import-smarthr-ui-local': 'error',
-      'smarthr/best-practice-for-reduce-redundant-calls': 'warn', // TODO: 2026/07に導入。問題なければerror化を検討予定
+      'smarthr/best-practice-for-reduce-redundant-calls': 'error',
       'smarthr/best-practice-for-remote-trigger-dialog': 'error',
       'smarthr/best-practice-for-rest-parameters': 'off', // TODO: 2025/12に導入。導入したプロダクトの数に応じてerror化を検討予定
       'smarthr/best-practice-for-spread-syntax': [ 'error', { fix: true } ],

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -76,7 +76,7 @@ export default [
       'smarthr/best-practice-for-text-component': 'error',
       'smarthr/best-practice-for-unnesessary-early-return': 'off', // TODO: 2025/12に導入。導入したプロダクトの数に応じてerror化を検討予定
       'smarthr/component-name': 'error',
-      'smarthr/design-system-guideline-bulk-action-row-button': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
+      'smarthr/design-system-guideline-bulk-action-row-button': 'error',
       'smarthr/design-system-guideline-prohibit-dialog-button-icon': 'warn', // TODO: 2026/04にwarn化。問題なければerrorに変更予定
       'smarthr/design-system-guideline-prohibit-double-icons': 'off',
       'smarthr/design-system-guideline-prohibit-information-panel-in-white-bg': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -55,7 +55,7 @@ export default [
       'smarthr/a11y-trigger-has-button': 'error',
       'smarthr/best-practice-for-async-current-target': 'error',
       'smarthr/best-practice-for-button-element': 'error',
-      'smarthr/best-practice-for-consecutive-definition-list': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
+      'smarthr/best-practice-for-consecutive-definition-list': 'error',
       'smarthr/best-practice-for-date': 'error',
       'smarthr/best-practice-for-data-test-attribute': 'off',
       'smarthr/best-practice-for-default-props': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -51,7 +51,7 @@ export default [
       'smarthr/a11y-prohibit-overflow-hidden': 'error',
       'smarthr/a11y-prohibit-sectioning-content-in-form': 'error',
       'smarthr/a11y-prohibit-useless-sectioning-fragment': 'error',
-      'smarthr/a11y-scroller-has-tabindex': 'warn', // TODO: 2026/04にwarn化。問題なければerrorに変更予定
+      'smarthr/a11y-scroller-has-tabindex': 'error',
       'smarthr/a11y-trigger-has-button': 'error',
       'smarthr/best-practice-for-async-current-target': 'error',
       'smarthr/best-practice-for-button-element': 'error',

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -58,7 +58,7 @@ export default [
       'smarthr/best-practice-for-consecutive-definition-list': 'error',
       'smarthr/best-practice-for-date': 'error',
       'smarthr/best-practice-for-data-test-attribute': 'off',
-      'smarthr/best-practice-for-default-props': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
+      'smarthr/best-practice-for-default-props': 'error',
       'smarthr/best-practice-for-interactive-element': 'error',
       'smarthr/best-practice-for-lazy-variable': ['warn', { fix: false }], // TODO: 2026/06にwarn化。問題なければerrorに変更予定。fix: false は問題なければ true にする
       'smarthr/best-practice-for-layouts': 'error',

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -64,7 +64,7 @@ export default [
       'smarthr/best-practice-for-layouts': 'error',
       'smarthr/best-practice-for-nested-attributes-array-index': 'error',
       'smarthr/best-practice-for-no-unnecessary-variable': 'off',
-      'smarthr/best-practice-for-unstable-dependencies': 'warn', // TODO: 2026/06に導入。導入したプロダクトの数に応じてerror化を検討予定
+      'smarthr/best-practice-for-unstable-dependencies': 'error',
       'smarthr/best-practice-for-optional-chaining': 'error',
       'smarthr/best-practice-for-prohibit-import-smarthr-ui-local': 'error',
       'smarthr/best-practice-for-reduce-redundant-calls': 'warn', // TODO: 2026/07に導入。問題なければerror化を検討予定

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -91,7 +91,7 @@ export default [
       'smarthr/require-declaration': 'off',
       'smarthr/require-export': 'off',
       'smarthr/require-i18n-text': 'warn', // TODO: 2025/11にwarn化。問題なければerrorに変更予定
-      'smarthr/require-i18n-translation-sync': 'off', // TODO: 2026/06に導入。問題なければwarn/error化を検討予定
+      'smarthr/require-i18n-translation-sync': 'warn', // TODO: 2026/07にwarn化。問題なければerrorに変更予定
       'smarthr/require-import': 'off',
       'smarthr/trim-props': 'error',
     }

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -36,7 +36,7 @@ export default [
 
       // original rules
       'smarthr/a11y-anchor-has-href-attribute': 'error',
-      'smarthr/a11y-aria-labelledby': 'warn', // TODO: 2026/03に導入。導入したプロダクトの数に応じてerror化を検討予定
+      'smarthr/a11y-aria-labelledby': 'error',
       'smarthr/a11y-clickable-element-has-text': 'error',
       'smarthr/a11y-form-control-in-form': 'error',
       'smarthr/a11y-heading-in-sectioning-content': 'error',

--- a/packages/eslint-config-smarthr/index.js
+++ b/packages/eslint-config-smarthr/index.js
@@ -79,7 +79,7 @@ export default [
       'smarthr/design-system-guideline-bulk-action-row-button': 'error',
       'smarthr/design-system-guideline-prohibit-dialog-button-icon': 'error',
       'smarthr/design-system-guideline-prohibit-double-icons': 'off',
-      'smarthr/design-system-guideline-prohibit-information-panel-in-white-bg': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
+      'smarthr/design-system-guideline-prohibit-information-panel-in-white-bg': 'error',
       'smarthr/format-import-path': 'off',
       'smarthr/format-translate-component': 'off',
       'smarthr/no-import-other-domain': 'off',

--- a/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config-smarthr/test/__snapshots__/snapshot.test.js.snap
@@ -2988,7 +2988,7 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       2,
     ],
     "smarthr/a11y-aria-labelledby": [
-      1,
+      2,
     ],
     "smarthr/a11y-clickable-element-has-text": [
       2,
@@ -3024,7 +3024,7 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       2,
     ],
     "smarthr/a11y-prohibit-overflow-hidden": [
-      1,
+      2,
     ],
     "smarthr/a11y-prohibit-sectioning-content-in-form": [
       2,
@@ -3033,7 +3033,7 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       2,
     ],
     "smarthr/a11y-scroller-has-tabindex": [
-      1,
+      2,
     ],
     "smarthr/a11y-trigger-has-button": [
       2,
@@ -3045,7 +3045,7 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       2,
     ],
     "smarthr/best-practice-for-consecutive-definition-list": [
-      1,
+      2,
     ],
     "smarthr/best-practice-for-data-test-attribute": [
       0,
@@ -3054,7 +3054,7 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       2,
     ],
     "smarthr/best-practice-for-default-props": [
-      1,
+      2,
     ],
     "smarthr/best-practice-for-interactive-element": [
       2,
@@ -3063,7 +3063,7 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       2,
     ],
     "smarthr/best-practice-for-lazy-variable": [
-      1,
+      2,
       {
         "fix": false,
       },
@@ -3081,7 +3081,7 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       2,
     ],
     "smarthr/best-practice-for-reduce-redundant-calls": [
-      1,
+      2,
     ],
     "smarthr/best-practice-for-remote-trigger-dialog": [
       2,
@@ -3103,28 +3103,28 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       0,
     ],
     "smarthr/best-practice-for-text-component": [
-      1,
+      2,
     ],
     "smarthr/best-practice-for-unnesessary-early-return": [
       0,
     ],
     "smarthr/best-practice-for-unstable-dependencies": [
-      1,
+      2,
     ],
     "smarthr/component-name": [
       2,
     ],
     "smarthr/design-system-guideline-bulk-action-row-button": [
-      1,
+      2,
     ],
     "smarthr/design-system-guideline-prohibit-dialog-button-icon": [
-      1,
+      2,
     ],
     "smarthr/design-system-guideline-prohibit-double-icons": [
       0,
     ],
     "smarthr/design-system-guideline-prohibit-information-panel-in-white-bg": [
-      1,
+      2,
     ],
     "smarthr/format-import-path": [
       0,
@@ -3160,7 +3160,7 @@ exports[`should match ESLint Configuration snapshot 1`] = `
       1,
     ],
     "smarthr/require-i18n-translation-sync": [
-      0,
+      1,
     ],
     "smarthr/require-import": [
       0,


### PR DESCRIPTION
## Summary
複数のESLintルールの重要度を変更しました。

### Error化したルール（warn → error）
- `smarthr/a11y-aria-labelledby`
- `smarthr/a11y-prohibit-overflow-hidden`
- `smarthr/a11y-scroller-has-tabindex`
- `smarthr/best-practice-for-consecutive-definition-list`
- `smarthr/best-practice-for-default-props`
- `smarthr/best-practice-for-lazy-variable`
- `smarthr/best-practice-for-unstable-dependencies`
- `smarthr/best-practice-for-text-component`
- `smarthr/design-system-guideline-bulk-action-row-button`
- `smarthr/design-system-guideline-prohibit-dialog-button-icon`
- `smarthr/design-system-guideline-prohibit-information-panel-in-white-bg`
- `smarthr/best-practice-for-reduce-redundant-calls`

### Warn化したルール（off → warn）
- `smarthr/require-i18n-translation-sync`

## Note
- oxlint-config-smarthrへの同期は別PRで対応予定

## Test plan
- [ ] テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)