### PR TITLE
feat: update ESLint rule severities in oxlint-config-smarthr

### DIFF
--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -213,7 +213,7 @@ const config = {
     'eslint-plugin-smarthr/a11y-prohibit-overflow-hidden': 'error',
     'eslint-plugin-smarthr/a11y-prohibit-sectioning-content-in-form': 'error',
     'eslint-plugin-smarthr/a11y-prohibit-useless-sectioning-fragment': 'error',
-    'eslint-plugin-smarthr/a11y-scroller-has-tabindex': 'warn',
+    'eslint-plugin-smarthr/a11y-scroller-has-tabindex': 'error',
     'eslint-plugin-smarthr/a11y-trigger-has-button': 'error',
     'eslint-plugin-smarthr/best-practice-for-async-current-target': 'error',
     'eslint-plugin-smarthr/best-practice-for-button-element': 'error',

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -229,7 +229,7 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-unstable-dependencies': 'error',
     'eslint-plugin-smarthr/best-practice-for-optional-chaining': 'error',
     'eslint-plugin-smarthr/best-practice-for-prohibit-import-smarthr-ui-local': 'error',
-    'eslint-plugin-smarthr/best-practice-for-reduce-redundant-calls': 'warn', // TODO: 2026/07に導入。問題なければerror化を検討予定
+    'eslint-plugin-smarthr/best-practice-for-reduce-redundant-calls': 'error',
     'eslint-plugin-smarthr/best-practice-for-remote-trigger-dialog': 'error',
     'eslint-plugin-smarthr/best-practice-for-rest-parameters': 'off',
     'eslint-plugin-smarthr/best-practice-for-spread-syntax': ['error', { fix: true }],

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -241,7 +241,7 @@ const config = {
     'eslint-plugin-smarthr/design-system-guideline-bulk-action-row-button': 'error',
     'eslint-plugin-smarthr/design-system-guideline-prohibit-dialog-button-icon': 'error',
     'eslint-plugin-smarthr/design-system-guideline-prohibit-double-icons': 'off',
-    'eslint-plugin-smarthr/design-system-guideline-prohibit-information-panel-in-white-bg': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
+    'eslint-plugin-smarthr/design-system-guideline-prohibit-information-panel-in-white-bg': 'error',
     'eslint-plugin-smarthr/format-import-path': 'off',
     'eslint-plugin-smarthr/format-translate-component': 'off',
     'eslint-plugin-smarthr/no-import-other-domain': 'off',

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -239,7 +239,7 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-unnesessary-early-return': 'off',
     'eslint-plugin-smarthr/component-name': 'error',
     'eslint-plugin-smarthr/design-system-guideline-bulk-action-row-button': 'error',
-    'eslint-plugin-smarthr/design-system-guideline-prohibit-dialog-button-icon': 'warn',
+    'eslint-plugin-smarthr/design-system-guideline-prohibit-dialog-button-icon': 'error',
     'eslint-plugin-smarthr/design-system-guideline-prohibit-double-icons': 'off',
     'eslint-plugin-smarthr/design-system-guideline-prohibit-information-panel-in-white-bg': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
     'eslint-plugin-smarthr/format-import-path': 'off',

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -238,7 +238,7 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-text-component': 'error',
     'eslint-plugin-smarthr/best-practice-for-unnesessary-early-return': 'off',
     'eslint-plugin-smarthr/component-name': 'error',
-    'eslint-plugin-smarthr/design-system-guideline-bulk-action-row-button': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
+    'eslint-plugin-smarthr/design-system-guideline-bulk-action-row-button': 'error',
     'eslint-plugin-smarthr/design-system-guideline-prohibit-dialog-button-icon': 'warn',
     'eslint-plugin-smarthr/design-system-guideline-prohibit-double-icons': 'off',
     'eslint-plugin-smarthr/design-system-guideline-prohibit-information-panel-in-white-bg': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -217,7 +217,7 @@ const config = {
     'eslint-plugin-smarthr/a11y-trigger-has-button': 'error',
     'eslint-plugin-smarthr/best-practice-for-async-current-target': 'error',
     'eslint-plugin-smarthr/best-practice-for-button-element': 'error',
-    'eslint-plugin-smarthr/best-practice-for-consecutive-definition-list': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
+    'eslint-plugin-smarthr/best-practice-for-consecutive-definition-list': 'error',
     'eslint-plugin-smarthr/best-practice-for-date': 'error',
     'eslint-plugin-smarthr/best-practice-for-data-test-attribute': 'off',
     'eslint-plugin-smarthr/best-practice-for-default-props': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -222,7 +222,7 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-data-test-attribute': 'off',
     'eslint-plugin-smarthr/best-practice-for-default-props': 'error',
     'eslint-plugin-smarthr/best-practice-for-interactive-element': 'error',
-    'eslint-plugin-smarthr/best-practice-for-lazy-variable': ['warn', { fix: false }], // TODO: 2026/06にwarn化。問題なければerrorに変更予定。fix: false は問題なければ true にする
+    'eslint-plugin-smarthr/best-practice-for-lazy-variable': ['error', { fix: false }],
     'eslint-plugin-smarthr/best-practice-for-layouts': 'error',
     'eslint-plugin-smarthr/best-practice-for-nested-attributes-array-index': 'error',
     'eslint-plugin-smarthr/best-practice-for-no-unnecessary-variable': 'off',

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -220,7 +220,7 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-consecutive-definition-list': 'error',
     'eslint-plugin-smarthr/best-practice-for-date': 'error',
     'eslint-plugin-smarthr/best-practice-for-data-test-attribute': 'off',
-    'eslint-plugin-smarthr/best-practice-for-default-props': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定
+    'eslint-plugin-smarthr/best-practice-for-default-props': 'error',
     'eslint-plugin-smarthr/best-practice-for-interactive-element': 'error',
     'eslint-plugin-smarthr/best-practice-for-lazy-variable': ['warn', { fix: false }], // TODO: 2026/06にwarn化。問題なければerrorに変更予定。fix: false は問題なければ true にする
     'eslint-plugin-smarthr/best-practice-for-layouts': 'error',

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -226,7 +226,7 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-layouts': 'error',
     'eslint-plugin-smarthr/best-practice-for-nested-attributes-array-index': 'error',
     'eslint-plugin-smarthr/best-practice-for-no-unnecessary-variable': 'off',
-    'eslint-plugin-smarthr/best-practice-for-unstable-dependencies': 'warn', // TODO: 2026/06に導入。導入したプロダクトの数に応じてerror化を検討予定
+    'eslint-plugin-smarthr/best-practice-for-unstable-dependencies': 'error',
     'eslint-plugin-smarthr/best-practice-for-optional-chaining': 'error',
     'eslint-plugin-smarthr/best-practice-for-prohibit-import-smarthr-ui-local': 'error',
     'eslint-plugin-smarthr/best-practice-for-reduce-redundant-calls': 'warn', // TODO: 2026/07に導入。問題なければerror化を検討予定

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -210,7 +210,7 @@ const config = {
     'eslint-plugin-smarthr/a11y-prohibit-checkbox-or-radio-in-table-cell': 'error',
     'eslint-plugin-smarthr/a11y-prohibit-input-maxlength-attribute': 'error',
     'eslint-plugin-smarthr/a11y-prohibit-input-placeholder': 'error',
-    'eslint-plugin-smarthr/a11y-prohibit-overflow-hidden': 'warn',
+    'eslint-plugin-smarthr/a11y-prohibit-overflow-hidden': 'error',
     'eslint-plugin-smarthr/a11y-prohibit-sectioning-content-in-form': 'error',
     'eslint-plugin-smarthr/a11y-prohibit-useless-sectioning-fragment': 'error',
     'eslint-plugin-smarthr/a11y-scroller-has-tabindex': 'warn',

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -235,7 +235,7 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-spread-syntax': ['error', { fix: true }],
     'eslint-plugin-smarthr/best-practice-for-tailwind-prohibit-root-margin': 'off',
     'eslint-plugin-smarthr/best-practice-for-tailwind-variants': 'off',
-    'eslint-plugin-smarthr/best-practice-for-text-component': 'warn',
+    'eslint-plugin-smarthr/best-practice-for-text-component': 'error',
     'eslint-plugin-smarthr/best-practice-for-unnesessary-early-return': 'off',
     'eslint-plugin-smarthr/component-name': 'error',
     'eslint-plugin-smarthr/design-system-guideline-bulk-action-row-button': 'warn', // TODO: 2026/05にwarn化。問題なければerrorに変更予定

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -253,7 +253,7 @@ const config = {
     'eslint-plugin-smarthr/require-declaration': 'off',
     'eslint-plugin-smarthr/require-export': 'off',
     'eslint-plugin-smarthr/require-i18n-text': 'warn',
-    'eslint-plugin-smarthr/require-i18n-translation-sync': 'off', // TODO: 2026/06に導入。問題なければwarn/error化を検討予定
+    'eslint-plugin-smarthr/require-i18n-translation-sync': 'warn', // TODO: 2026/07にwarn化。問題なければerrorに変更予定
     'eslint-plugin-smarthr/require-import': 'off',
     'eslint-plugin-smarthr/trim-props': 'error',
   },

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -231,12 +231,12 @@ const config = {
     'eslint-plugin-smarthr/best-practice-for-prohibit-import-smarthr-ui-local': 'error',
     'eslint-plugin-smarthr/best-practice-for-reduce-redundant-calls': 'error',
     'eslint-plugin-smarthr/best-practice-for-remote-trigger-dialog': 'error',
-    'eslint-plugin-smarthr/best-practice-for-rest-parameters': 'off',
-    'eslint-plugin-smarthr/best-practice-for-spread-syntax': ['error', { fix: true }],
+    'eslint-plugin-smarthr/best-practice-for-rest-parameters': 'off', // TODO: 2025/12に導入。導入したプロダクトの数に応じてerror化を検討予定
+    'eslint-plugin-smarthr/best-practice-for-spread-syntax': [ 'error', { fix: true } ],
     'eslint-plugin-smarthr/best-practice-for-tailwind-prohibit-root-margin': 'off',
     'eslint-plugin-smarthr/best-practice-for-tailwind-variants': 'off',
     'eslint-plugin-smarthr/best-practice-for-text-component': 'error',
-    'eslint-plugin-smarthr/best-practice-for-unnesessary-early-return': 'off',
+    'eslint-plugin-smarthr/best-practice-for-unnesessary-early-return': 'off', // TODO: 2025/12に導入。導入したプロダクトの数に応じてerror化を検討予定
     'eslint-plugin-smarthr/component-name': 'error',
     'eslint-plugin-smarthr/design-system-guideline-bulk-action-row-button': 'error',
     'eslint-plugin-smarthr/design-system-guideline-prohibit-dialog-button-icon': 'error',
@@ -252,7 +252,7 @@ const config = {
     'eslint-plugin-smarthr/require-barrel-import': 'error',
     'eslint-plugin-smarthr/require-declaration': 'off',
     'eslint-plugin-smarthr/require-export': 'off',
-    'eslint-plugin-smarthr/require-i18n-text': 'warn',
+    'eslint-plugin-smarthr/require-i18n-text': 'warn', // TODO: 2025/11にwarn化。問題なければerrorに変更予定
     'eslint-plugin-smarthr/require-i18n-translation-sync': 'warn', // TODO: 2026/07にwarn化。問題なければerrorに変更予定
     'eslint-plugin-smarthr/require-import': 'off',
     'eslint-plugin-smarthr/trim-props': 'error',

--- a/packages/oxlint-config-smarthr/index.js
+++ b/packages/oxlint-config-smarthr/index.js
@@ -198,7 +198,7 @@ const config = {
 
     // === eslint-plugin-smarthr ===
     'eslint-plugin-smarthr/a11y-anchor-has-href-attribute': 'error',
-    'eslint-plugin-smarthr/a11y-aria-labelledby': 'warn',
+    'eslint-plugin-smarthr/a11y-aria-labelledby': 'error',
     'eslint-plugin-smarthr/a11y-clickable-element-has-text': 'error',
     'eslint-plugin-smarthr/a11y-form-control-in-form': 'error',
     'eslint-plugin-smarthr/a11y-heading-in-sectioning-content': 'error',


### PR DESCRIPTION
## Summary
複数のESLintルールの重要度を変更しました（eslint-config-smarthrと同じ設定）。

### Error化したルール（warn → error）
- `eslint-plugin-smarthr/a11y-aria-labelledby`
- `eslint-plugin-smarthr/a11y-prohibit-overflow-hidden`
- `eslint-plugin-smarthr/a11y-scroller-has-tabindex`
- `eslint-plugin-smarthr/best-practice-for-consecutive-definition-list`
- `eslint-plugin-smarthr/best-practice-for-default-props`
- `eslint-plugin-smarthr/best-practice-for-lazy-variable`
- `eslint-plugin-smarthr/best-practice-for-unstable-dependencies`
- `eslint-plugin-smarthr/best-practice-for-text-component`
- `eslint-plugin-smarthr/design-system-guideline-bulk-action-row-button`
- `eslint-plugin-smarthr/design-system-guideline-prohibit-dialog-button-icon`
- `eslint-plugin-smarthr/design-system-guideline-prohibit-information-panel-in-white-bg`
- `eslint-plugin-smarthr/best-practice-for-reduce-redundant-calls`

### Warn化したルール（off → warn）
- `eslint-plugin-smarthr/require-i18n-translation-sync`

## Related PR
- #1476 (eslint-config-smarthr version)

## Test plan
- [ ] テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)