### PR TITLE
fix: バレルファイルの純粋性チェックが関数内のローカル宣言まで報告する問題を修正

### DIFF
--- a/packages/eslint-plugin-smarthr/rules/require-barrel-import/README.md
+++ b/packages/eslint-plugin-smarthr/rules/require-barrel-import/README.md
@@ -354,6 +354,19 @@ export interface ComponentAPI {
 }
 ```
 
+なお、報告されるのは**ファイルのトップレベルの宣言のみ**です。関数やブロックの内部にあるローカル宣言は報告されません。
+それを含むトップレベルの宣言が報告されるため、そちらを別ファイルへ切り出せば解消します。
+
+```typescript
+// ❌ export const の1件のみ報告される（内部の const は報告されない）
+export const useContainer = () => {
+  const foo = 'bar'
+  const baz = 'qux'
+
+  return { foo, baz }
+}
+```
+
 ### ✅ 許可されるパターン
 
 ```typescript

--- a/packages/eslint-plugin-smarthr/rules/require-barrel-import/utils.js
+++ b/packages/eslint-plugin-smarthr/rules/require-barrel-import/utils.js
@@ -15,6 +15,31 @@ const TARGET_EXTS = ['ts', 'tsx', 'js', 'jsx']
 const isBarrelFile = (filePath, barrelFileNames) => barrelFileNames.includes(path.basename(filePath, path.extname(filePath)))
 
 /**
+ * ファイルのトップレベルに書かれた宣言かどうか
+ * 関数やブロックの内部にあるローカル宣言は、それを含むトップレベルの宣言が
+ * 報告されるため、重複して報告しない
+ * @param {object} node - 判定対象のnode
+ * @returns {boolean}
+ */
+const isTopLevelDeclaration = (node) => {
+  const parent = node.parent
+
+  if (!parent) {
+    return false
+  }
+
+  if (parent.type === 'Program') {
+    return true
+  }
+
+  // export const Foo = ... / export default function Foo() {} 等
+  return (
+    (parent.type === 'ExportNamedDeclaration' || parent.type === 'ExportDefaultDeclaration') &&
+    parent.parent?.type === 'Program'
+  )
+}
+
+/**
  * バレルファイルの純粋性をチェックするビジター
  * バレルファイルは re-export のみを行うべきで、以下は禁止:
  * - import文
@@ -34,6 +59,11 @@ const createBarrelPurityVisitor = (context, barrelFileNames) => {
 
   // エラー報告の共通処理
   const reportPurityError = (node) => {
+    // トップレベル以外（関数内のローカル宣言等）は報告しない
+    if (!isTopLevelDeclaration(node)) {
+      return
+    }
+
     context.report({
       node,
       message: `バレルファイルは設置されたディレクトリ外へのexportが責務です。

--- a/packages/eslint-plugin-smarthr/test/require-barrel-import.js
+++ b/packages/eslint-plugin-smarthr/test/require-barrel-import.js
@@ -1589,6 +1589,79 @@ ruleTester.run('require-barrel-import', rule, {
       ],
     },
 
+    // 純粋性チェックはトップレベルの宣言のみを報告する
+    // 関数内のローカル宣言まで報告すると、1つの違反が宣言の数だけ報告されてしまう
+
+    // 22. export const の関数内にローカル変数がある場合、export const のみ報告
+    {
+      code: `export const useContainer = () => {
+        const foo = 'bar'
+        const baz = 'qux'
+        return { foo, baz }
+      }`,
+      filename: (() => {
+        createFixture('barrel-purity-nested-const', {
+          'components': {
+            'index.tsx': '',
+          },
+        })
+        return `${fixturesRoot}/barrel-purity-nested-const/components/index.tsx`
+      })(),
+      errors: [
+        {
+          message: /バレルファイルは設置されたディレクトリ外へのexportが責務です/,
+        },
+      ],
+    },
+
+    // 23. トップレベルのfunction内にローカル変数がある場合、functionのみ報告
+    {
+      code: `function init() {
+        const store = {}
+        function render() {}
+        class Renderer {}
+        return store
+      }`,
+      filename: (() => {
+        createFixture('barrel-purity-nested-in-function', {
+          'components': {
+            'index.tsx': '',
+          },
+        })
+        return `${fixturesRoot}/barrel-purity-nested-in-function/components/index.tsx`
+      })(),
+      errors: [
+        {
+          message: /バレルファイルは設置されたディレクトリ外へのexportが責務です/,
+        },
+      ],
+    },
+
+    // 24. export default function内にローカル宣言がある場合、export defaultのみ報告
+    {
+      code: `export default function Page() {
+        const theme = {}
+        type Props = { theme: typeof theme }
+        return theme as Props['theme']
+      }`,
+      filename: (() => {
+        createFixture('barrel-purity-nested-in-export-default', {
+          'components': {
+            'index.tsx': '',
+          },
+        })
+        return `${fixturesRoot}/barrel-purity-nested-in-export-default/components/index.tsx`
+      })(),
+      languageOptions: {
+        parser: require('typescript-eslint').parser,
+      },
+      errors: [
+        {
+          message: /バレルファイルは設置されたディレクトリ外へのexportが責務です/,
+        },
+      ],
+    },
+
     // ========================================
     // 同じディレクトリのバレルファイル間での重複export検出
     // ========================================


### PR DESCRIPTION
## Summary

- バレルファイルの純粋性チェックが、関数やブロック内のローカル宣言まで1件ずつ報告していた問題を修正
- 違反は「バレルファイルに実装がある」の1つで、直し方も「その宣言を別ファイルへ切り出す」の1つだけなので、内側の報告は情報量がないと判断
- 報告前に `isTopLevelDeclaration()` でトップレベルの宣言かを判定するようにした
- 検出範囲（エラーを持つファイル）は変えていない

## Changes

- `rules/require-barrel-import/utils.js`: `isTopLevelDeclaration()` を追加し、`reportPurityError()` でトップレベル以外は報告しないようにした
- `rules/require-barrel-import/README.md`: 報告対象はトップレベルの宣言のみである旨を追記
- `test/require-barrel-import.js`: 関数内のローカル宣言が報告されないケースのテストを追加


## Test plan

- [x] テストが全て通過することを確認
- [ ] CIが通過することを確認
